### PR TITLE
Restart Mongodb when service is not ready

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -156,6 +156,10 @@ class MongoDBCharm(CharmBase):
         if not self.mongo.is_ready():
             status_message = "service not ready yet"
             self.unit.status = WaitingStatus(status_message)
+            # TODO: remove container restarting here when Pebble
+            # does this automatically
+            container = self.unit.get_container("mongodb")
+            container.restart("mongodb")
             return
 
         if not self._stored.mongodb_initialized:


### PR DESCRIPTION
It has been observed that sometimes the MongoDB workload
fails to start, hence the charm is stuck in a mongodb "service not ready
yet" waiting status. This commit adds a temporary fix by restarting
the workload container if this state is observed. In the future
this commit can be reverted when Pebble automatically restarts
containers that have not started.