### PR TITLE
Sets the db relation data on start

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -126,6 +126,11 @@ class MongoDBCharm(CharmBase):
                 self._stored.mongodb_initialized = True
                 self.peers.data[self.app][
                     "replica_set_hosts"] = json.dumps(self.mongo.cluster_hosts)
+
+                # Now that we've initialized MongoDB, we can finally set the necessary
+                # relation data for the relations that were already created.
+                self.mongo_provider = MongoProvider(self, 'database')
+                self.mongo_provider.update_all_db_relations()
             except Exception as e:
                 logger.info("Deferring on_start since : error={}".format(e))
                 self._on_update_status(event)

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -94,6 +94,25 @@ class TestCharm(unittest.TestCase):
             self.assertIn("INFO:charm:Deferring on_start since : error=Not Initialized",
                           sorted(logger.output))
 
+    @patch('mongoserver.MongoDB.initialize_replica_set')
+    @patch('mongoserver.MongoDB.is_ready')
+    def test_on_start_initialize_relations_data(self, is_ready, initialize):
+        is_ready.return_value = True
+        self.harness.set_leader(True)
+        db_rel_id = self.harness.add_relation("database", "database")
+        data = self.harness.get_relation_data(db_rel_id, self.harness.model.app.name)
+        self.assertEqual({}, data)
+
+        self.harness.charm.on.start.emit()
+
+        charm = self.harness.charm
+        self.assertNotIn("mongo_provider", charm.__dict__)
+        is_ready.assert_called()
+        initialize.assert_called()
+
+        data = self.harness.get_relation_data(db_rel_id, self.harness.model.app.name)
+        self.assertDictEqual({}, data)
+
 
 def replica_set_name(plan, service="mongodb"):
     plan_dict = plan.to_dict()

--- a/tests/test_mongoprovider.py
+++ b/tests/test_mongoprovider.py
@@ -91,10 +91,7 @@ class MongoDBCharm(CharmBase):
     def __init__(self, *args, **kwargs):
         super().__init__(*args)
         self.mongo = Mongo(self)
-        self.provider = MongoProvider(self,
-                                      self.model.config['relation_name'],
-                                      service="mongodb",
-                                      version=self.model.config['db_version'])
+        self.provider = MongoProvider(self, 'database')
 
     @property
     def is_joined(self):


### PR DESCRIPTION
Currently, the MongoDB charm does not set any relation data into the related charms if they were related before the charm finished starting. A workaround for this was to recreate the relations after the MongoDB charm became active.

This PR addresses the issue, and adds a unit test that verifies this aspect, and it has been updated to verify that the relation data is indeed set into existing relations after MongoDB starts.

Also fixes the ``test_mongoprovider.py`` tests. A previous change [1] removed the dependency on ``ops.relation``, but the unit tests were not updated, which resulted in them failing.

[1] https://github.com/canonical/mongodb-k8s-operator/pull/17