### PR TITLE
Pins pymongo to 3.12.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 git+git://github.com/canonical/operator#egg=ops
-pymongo
+pymongo=3.12.1


### PR DESCRIPTION
Currently, if you try to ``charmcraft pack`` this charm, ``pymongo==4.0.1`` is installed automatically. The charm won't work with this version, causing errors such as this:

```
*** pymongo.errors.ServerSelectionTimeoutError: No servers match selector "Primary()", Timeout: 1.0s, Topology Description: <TopologyDescription id: 61f1399bbda90654b5f91687, topology_type: Unknown, servers: [<ServerDescription ('mongodb-0.mongodb-endpoints', 27017) server_type: RSGhost, rtt: 0.013509276671713656>]>
```

Adding ``directConnection=True`` to the MongoClient [1] could solve this issue, but it cannot be used when there are multiple peers.

```
======================================================================
ERROR: test_replica_set_is_reconfigured_when_peer_joins (tests.test_charm.TestCharm)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python3.8/unittest/mock.py", line 1325, in patched
    return func(*newargs, **newkeywargs)
  File "/home/ubuntu/workdir/mongodb-k8s-operator/tests/test_charm.py", line 45, in test_replica_set_is_reconfigured_when_peer_joins
    self.harness.update_relation_data(self.peer_rel_id,
  File "/usr/local/lib/python3.8/dist-packages/ops/testing.py", line 801, in update_relation_data
    self._emit_relation_changed(relation_id, app_or_unit)
  File "/usr/local/lib/python3.8/dist-packages/ops/testing.py", line 818, in _emit_relation_changed
    self._charm.on[rel_name].relation_changed.emit(*args)
  File "/usr/local/lib/python3.8/dist-packages/ops/framework.py", line 276, in emit
    framework._emit(event)
  File "/usr/local/lib/python3.8/dist-packages/ops/framework.py", line 736, in _emit
    self._reemit(event_path)
  File "/usr/local/lib/python3.8/dist-packages/ops/framework.py", line 783, in _reemit
    custom_handler(event)
  File "/home/ubuntu/workdir/mongodb-k8s-operator/src/charm.py", line 201, in _reconfigure
    self._on_update_status(event)
  File "/home/ubuntu/workdir/mongodb-k8s-operator/src/charm.py", line 161, in _on_update_status
    if not self.mongo.is_ready():
  File "/home/ubuntu/workdir/mongodb-k8s-operator/src/mongoserver.py", line 55, in is_ready
    client = self.client()
  File "/home/ubuntu/workdir/mongodb-k8s-operator/src/mongoserver.py", line 43, in client
    return MongoClient(
  File "/usr/local/lib/python3.8/dist-packages/pymongo/mongo_client.py", line 720, in __init__
    _check_options(seeds, opts)
  File "/usr/local/lib/python3.8/dist-packages/pymongo/uri_parser.py", line 381, in _check_options
    raise ConfigurationError(
pymongo.errors.ConfigurationError: Cannot specify multiple hosts with directConnection=true
```

Pinning ``pymongo`` to ``3.12.1``, the version used by the revision 8 of the Charm which worked.

[1] https://jira.mongodb.org/browse/PYTHON-3027