### PR TITLE
WIP: Adds directConnection=True to the MongoClient

### DIFF
--- a/src/mongoserver.py
+++ b/src/mongoserver.py
@@ -40,7 +40,10 @@ class MongoDB():
         Retruns:
             A pymongo :class:`MongoClient` object.
         """
-        return MongoClient(self.replica_set_uri(), serverSelectionTimeoutMS=1000)
+        return MongoClient(
+            self.replica_set_uri(),
+            directConnection=True,
+            serverSelectionTimeoutMS=1000)
 
     def is_ready(self):
         """Is the MongoDB server ready to services requests.


### PR DESCRIPTION
Currently, if you try to ``charmcraft pack`` this charm, ``pymongo==4.0.1`` is installed automatically. The charm won't work with this version, causing errors such as this:

```
*** pymongo.errors.ServerSelectionTimeoutError: No servers match selector "Primary()",
Timeout: 1.0s, Topology Description: <TopologyDescription id: 61f1399bbda90654b5f91687,
topology_type: Unknown, servers: [<ServerDescription ('mongodb-0.mongodb-endpoints', 27017)
server_type: RSGhost, rtt: 0.013509276671713656>]>
```

Adding ``directConnection=True`` to the MongoClient solves the issue [1].

[1] https://jira.mongodb.org/browse/PYTHON-3027