### PR TITLE
Remove server selection timeout option

### DIFF
--- a/src/mongoserver.py
+++ b/src/mongoserver.py
@@ -40,7 +40,7 @@ class MongoDB():
         Retruns:
             A pymongo :class:`MongoClient` object.
         """
-        return MongoClient(self.replica_set_uri(), serverSelectionTimeoutMS=1000)
+        return MongoClient(self.replica_set_uri())
 
     def is_ready(self):
         """Is the MongoDB server ready to services requests.


### PR DESCRIPTION
This commit removes the setting of ServerSelectionTimeoutMS from
the MongoClient constructor arguments. This is because in
PyMongo 4 the default value is 30 that is longer than what it
is begin currently set too.