### PR TITLE
Workarounds for breaking changes in PyMongo and MongoDB

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-git+git://github.com/canonical/operator#egg=ops
-pymongo
+ops
+pymongo >= 3.12, < 4.0

--- a/src/charm.py
+++ b/src/charm.py
@@ -194,6 +194,11 @@ class MongoDBCharm(CharmBase):
         if self.need_replica_set_reconfiguration:
             try:
                 self.mongo.reconfigure_replica_set(self.mongo.cluster_hosts)
+                # since a new replica set has been configured,
+                # now update the set of replica set hosts
+                self.peers.data[self.app][
+                    "replica_set_hosts"] = json.dumps(self.mongo.cluster_hosts)
+                logger.debug("Reconfigured replica set")
             except Exception as e:
                 logger.info("Deferring reconfigure since : error={}".format(e))
                 event.defer()

--- a/src/mongoserver.py
+++ b/src/mongoserver.py
@@ -2,7 +2,11 @@ import secrets
 import string
 
 from pymongo import MongoClient
-from pymongo.errors import AutoReconnect, ServerSelectionTimeoutError
+from pymongo.errors import (
+    AutoReconnect,
+    OperationFailure,
+    ServerSelectionTimeoutError
+)
 import logging
 
 
@@ -111,7 +115,7 @@ class MongoDB():
         db = client["admin"]
         try:
             db.command("shutdown")
-        except (AutoReconnect, ServerSelectionTimeoutError):
+        except (AutoReconnect, OperationFailure, ServerSelectionTimeoutError):
             logger.debug("MongoDB shutdown failed")
         client.close()
 


### PR DESCRIPTION
The manner in which replica sets are initialized in PyMongo 4 and MongoDB 5 seems to have been changed. This PR implements a workaround to temporarily resolve this issue.