### PR TITLE
Moved key file from persistent to container storage

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -16,8 +16,6 @@ containers:
     mounts:
       - storage: db
         location: /data/db
-      - storage: secrets
-        location: /var/lib/mongodb-secrets
 resources:
   mongodb-image:
     type: oci-image
@@ -25,6 +23,4 @@ resources:
     upstream-source: 'mongo:latest'
 storage:
   db:
-    type: filesystem
-  secrets:
     type: filesystem

--- a/src/charm.py
+++ b/src/charm.py
@@ -15,7 +15,7 @@ from ops.model import (
     MaintenanceStatus
 )
 
-from pebble_layers import MongoLayers, SECRET_PATH, KEY_FILE
+from pebble_layers import MongoLayers, KEY_FILE
 from mongoserver import MongoDB, MONGODB_PORT
 from mongoprovider import MongoProvider
 
@@ -336,9 +336,8 @@ class MongoDBCharm(CharmBase):
         Raises:
             :class:`ops.pebble.ConnectionError` if pebble is not ready
         """
-        file_path = SECRET_PATH + "/" + KEY_FILE
         try:
-            key_file = container.pull(file_path)
+            key_file = container.pull(KEY_FILE)
             key = key_file.read()
         except PathError:
             return False
@@ -353,9 +352,8 @@ class MongoDBCharm(CharmBase):
         Raises:
             :class:`ops.pebble.ConnectionError` if pebble is not ready
         """
-        file_path = SECRET_PATH + "/" + KEY_FILE
         try:
-            container.push(file_path,
+            container.push(KEY_FILE,
                            self.security_key,
                            permissions=0o400,
                            user="mongodb",

--- a/src/pebble_layers.py
+++ b/src/pebble_layers.py
@@ -2,8 +2,7 @@
 import logging
 from ops.pebble import Layer
 
-SECRET_PATH = "/var/lib/mongodb-secrets"
-KEY_FILE = "key.file"
+KEY_FILE = "/key.file"
 
 logger = logging.getLogger(__name__)
 
@@ -67,7 +66,7 @@ class MongoLayers:
         """
         args = ["mongod"]
         replica_set_option = "--replSet {}".format(self._replica_set_name)
-        keyfile_option = "--keyFile {}/{}".format(SECRET_PATH, KEY_FILE)
+        keyfile_option = "--keyFile {}".format(KEY_FILE)
         args.extend(replica_set_option.split(" "))
         args.extend(keyfile_option.split(" "))
         return args


### PR DESCRIPTION
The MongoDB charm was initaly built as a pod spec charm. The
mongod daemon expects its key file to be present before it is
started. Hence the pod spec charm used a Kubernetes init container
and a persistent storage to create and populate the key file.
This is no longer necessary for a side car charm, since key files
can be pushed to the workload container before starting the
workload. This is exactly the workflow implemented by this

Closes: #16