### PR TITLE
Trap additional exception when checking ready status

### DIFF
--- a/src/mongoserver.py
+++ b/src/mongoserver.py
@@ -74,9 +74,9 @@ class MongoDB():
         ready = False
         client = self.client(host)
         try:
-            client.server_info()
+            _ = client.server_info()
             ready = True
-        except ServerSelectionTimeoutError:
+        except (OperationFailure, ServerSelectionTimeoutError):
             logger.debug("mongodb service is not ready yet.")
         finally:
             client.close()
@@ -277,7 +277,7 @@ class MongoDB():
         try:
             info = client.server_info()
             return info['version']
-        except ServerSelectionTimeoutError:
+        except (OperationFailure, ServerSelectionTimeoutError):
             logger.debug("mongodb service is not ready yet.")
         finally:
             client.close()


### PR DESCRIPTION
The MongoDB charm checks the status of MongoDB prior to
attempting replica set initialization. This check uses
a try and fail approach. The failure is detected through
exceptions rasied which are trapped. Previous version of
PyMongo raised ServerSelectionTimeout exception. The
current version raises OperationFailure exception. This
commit updates the code to trap the new exception.

Closes: #36