### PR TITLE
Install poetry as a tox dependency

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,8 +14,6 @@ jobs:
         uses: actions/checkout@v2
       - name: Install tox
         run: python3 -m pip install tox
-      - name: Install poetry
-        run: curl -sSL https://install.python-poetry.org | python3 -
       - name: Run linters
         run: tox -e lint
   unit-test:
@@ -26,8 +24,6 @@ jobs:
         uses: actions/checkout@v2
       - name: Install tox
         run: python3 -m pip install tox
-      - name: Install poetry
-        run: curl -sSL https://install.python-poetry.org | python3 -
       - name: Run tests
         run: tox -e unit
   integration-test-microk8s:
@@ -45,8 +41,6 @@ jobs:
           bootstrap-options: "--agent-version 2.9.29"
       - name: Install tox
         run: python3 -m pip install tox
-      - name: Install poetry
-        run: curl -sSL https://install.python-poetry.org | python3 -
       - name: Run integration tests
         # set a predictable model name so it can be consumed by charm-logdump-action
         run: sg microk8s -c "tox -e integration -- --model testing"

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -17,3 +17,6 @@ bases:
     run-on:
     - name: "ubuntu"
       channel: "20.04"
+parts:
+  charm:
+    charm-binary-python-packages: [setuptools]

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -19,4 +19,9 @@ bases:
       channel: "20.04"
 parts:
   charm:
+    build-packages:
+      - libffi-dev
+      - libssl-dev
+      - rustc
+      - cargo
     charm-binary-python-packages: [setuptools]

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ envlist = fmt, lint, unit
 src_path = {toxinidir}/src/
 tst_path = {toxinidir}/tests/
 lib_path = {toxinidir}/lib/charms/operator_name_with_underscores
-all_path = {[vars]src_path} {[vars]tst_path} 
+all_path = {[vars]src_path} {[vars]tst_path}
 
 [testenv]
 whitelist_externals = poetry
@@ -22,6 +22,8 @@ passenv =
   PYTHONPATH
   CHARM_BUILD_DIR
   MODEL_SETTINGS
+deps =
+    poetry
 
 [testenv:fmt]
 description = Apply coding style standards to code


### PR DESCRIPTION
# Issue

* Poetry is not installed by tox and calls to it rely on it being installed and working system wide.

# Solution

* Add poetry as a dependency to tox.
* Remove CI installation of poetry

# Context

# Testing

* No additional testing should be necessary beyond existing tests working as intended.

# Release Notes
