### PR TITLE
Adding network cut and unique cluster DBs tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -69,6 +69,8 @@ jobs:
           provider: microk8s
           # This is needed until https://bugs.launchpad.net/juju/+bug/1977582 is fixed
           bootstrap-options: "--agent-version 2.9.29"
+      - name: Install Helm
+        run: /usr/bin/sudo snap install helm3
       - name: Install tox
         run: python3 -m pip install tox
       - name: Run HA integration tests

--- a/tests/integration/ha_tests/conftest.py
+++ b/tests/integration/ha_tests/conftest.py
@@ -1,0 +1,26 @@
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+from pathlib import Path
+from typing import Optional
+
+import pytest
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--mongodb_charm",
+        action="store",
+        default=None,
+        help="The location of prebuilt mongodb-k8s charm",
+    )
+
+
+@pytest.fixture
+def cmd_mongodb_charm(request) -> Optional[Path]:
+    """Fixture to optionally pass a prebuilt charm to deploy."""
+    charm_path = request.config.getoption("--mongodb_charm")
+    if charm_path:
+        path = Path(charm_path).absolute()
+        if path.exists():
+            return path

--- a/tests/integration/ha_tests/helpers.py
+++ b/tests/integration/ha_tests/helpers.py
@@ -525,9 +525,11 @@ async def verify_writes(ops_test: OpsTest) -> int:
 
 
 async def get_other_mongodb_direct_client(ops_test: OpsTest, app_name: str) -> MongoClient:
-    """Returns a direct mongodb client to the second mongodb cluster."""
-    # Since the other mongodb-k8s application will have separate IPs and credentials, connection
-    # URI must be generated separately.
+    """Returns a direct mongodb client to the second mongodb cluster.
+
+    Since the second mongodb-k8s application will have separate IPs and credentials, connection URI
+     must be generated separately.
+    """
     unit = ops_test.model.applications[app_name].units[0]
     action = await unit.run_action("get-password")
     action = await action.wait()
@@ -576,7 +578,7 @@ def deploy_chaos_mesh(namespace: str) -> None:
 
 
 def destroy_chaos_mesh(namespace: str) -> None:
-    """Deploy chaos mesh to the provided namespace.
+    """Destroy chaos mesh on a provided namespace.
 
     Cleans up the test K8S from test related dependencies.
 
@@ -596,10 +598,10 @@ def destroy_chaos_mesh(namespace: str) -> None:
 def isolate_instance_from_cluster(ops_test: OpsTest, unit_name: str) -> None:
     """Apply a NetworkChaos file to use chaos-mesh to simulate a network cut."""
     with tempfile.NamedTemporaryFile() as temp_file:
+        # Generates a manifest for chaosmesh to simulate network failure for a pod
         with open(
             "tests/integration/ha_tests/manifests/chaos_network_loss.yml", "r"
         ) as chaos_network_loss_file:
-            # Generates a manifest for chaosmesh to simulate a network failure for a pod
             template = string.Template(chaos_network_loss_file.read())
             chaos_network_loss = template.substitute(
                 namespace=ops_test.model.info.name,

--- a/tests/integration/ha_tests/helpers.py
+++ b/tests/integration/ha_tests/helpers.py
@@ -253,8 +253,6 @@ async def get_process_pid(
     ), f"Failed getting pid, unit={unit_name}, container={container_name}, process={process}"
 
     stripped_pid = pid.strip()
-    if not stripped_pid:
-        raise Exception()
     assert (
         stripped_pid
     ), f"Failed stripping pid, unit={unit_name}, container={container_name}, process={process}, {pid}"

--- a/tests/integration/ha_tests/helpers.py
+++ b/tests/integration/ha_tests/helpers.py
@@ -1,7 +1,6 @@
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-import json
 import os
 import string
 import subprocess
@@ -9,7 +8,7 @@ import tempfile
 from asyncio import gather
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import List, Optional
 
 import ops
 import yaml
@@ -47,6 +46,7 @@ class ProcessRunningError(Exception):
 
 async def get_application_name(ops_test: OpsTest, application_name: str) -> str:
     """Returns the Application in the juju model that matches the provided application name.
+
     This enables us to retrieve the name of the deployed application in an existing model, while
      ignoring some test specific applications.
     Note: if multiple applications with the application name exist, the first one found will be
@@ -70,6 +70,7 @@ async def scale_application(
     ops_test: OpsTest, application_name: str, desired_count: int, wait: bool = True
 ) -> None:
     """Scale a given application to the desired unit count.
+
     Args:
         ops_test: The ops test framework
         application_name: The name of the application
@@ -98,6 +99,7 @@ async def relate_mongodb_and_application(
     ops_test: OpsTest, mongodb_application_name: str, application_name: str
 ) -> None:
     """Relates the mongodb and application charms.
+
     Args:
         ops_test: The ops test framework
         mongodb_application_name: The mongodb charm application name
@@ -127,6 +129,7 @@ async def deploy_and_scale_mongodb(
     charm_path: Optional[Path] = None,
 ) -> str:
     """Deploys and scales the mongodb application charm.
+
     Args:
         ops_test: The ops test framework
         check_for_existing_application: Whether to check for existing mongodb applications
@@ -173,6 +176,7 @@ async def deploy_and_scale_mongodb(
 
 async def deploy_and_scale_application(ops_test: OpsTest) -> str:
     """Deploys and scales the test application charm.
+
     Args:
         ops_test: The ops test framework
     """
@@ -208,6 +212,7 @@ async def deploy_and_scale_application(ops_test: OpsTest) -> str:
 
 def is_relation_joined(ops_test: OpsTest, endpoint_one: str, endpoint_two: str) -> bool:
     """Check if a relation is joined.
+
     Args:
         ops_test: The ops test object passed into every test case
         endpoint_one: The first endpoint of the relation
@@ -224,6 +229,7 @@ async def get_process_pid(
     ops_test: OpsTest, unit_name: str, container_name: str, process: str
 ) -> int:
     """Return the pid of a process running in a given unit.
+
     Args:
         ops_test: The ops test object passed into every test case
         unit_name: The name of the unit
@@ -260,6 +266,7 @@ async def send_signal_to_pod_container_process(
     ops_test: OpsTest, unit_name: str, container_name: str, process: str, signal_code: str
 ) -> None:
     """Send the specified signal to a pod container process.
+
     Args:
         ops_test: The ops test framework
         unit_name: The name of the unit to send signal to
@@ -321,6 +328,7 @@ async def count_primaries(ops_test: OpsTest) -> int:
 
 async def fetch_replica_set_members(ops_test: OpsTest) -> List[str]:
     """Fetches the hosts listed as replica set members in the MongoDB replica set configuration.
+
     Args:
         ops_test: reference to deployment.
     """
@@ -541,6 +549,7 @@ def retrieve_entries(client, db_name, collection_name, query_field):
 
 def deploy_chaos_mesh(namespace: str) -> None:
     """Deploy chaos mesh to the provided namespace.
+
     Args:
         namespace: The namespace to deploy chaos mesh to
     """
@@ -561,6 +570,7 @@ def deploy_chaos_mesh(namespace: str) -> None:
 
 def destroy_chaos_mesh(namespace: str) -> None:
     """Deploy chaos mesh to the provided namespace.
+
     Args:
         namespace: The namespace to deploy chaos mesh to
     """

--- a/tests/integration/ha_tests/manifests/chaos_network_loss.yml
+++ b/tests/integration/ha_tests/manifests/chaos_network_loss.yml
@@ -1,5 +1,7 @@
 apiVersion: chaos-mesh.org/v1alpha1
 kind: NetworkChaos
+# Directive for chaosmesh to simulate a network loss for a pod for the network cut HA test.
+# Namespace and pod ID are templated and populated by the test.
 metadata:
   name: network-loss-primary
   namespace: $namespace

--- a/tests/integration/ha_tests/manifests/chaos_network_loss.yml
+++ b/tests/integration/ha_tests/manifests/chaos_network_loss.yml
@@ -1,0 +1,16 @@
+apiVersion: chaos-mesh.org/v1alpha1
+kind: NetworkChaos
+metadata:
+  name: network-loss-primary
+  namespace: $namespace
+spec:
+  action: loss
+  mode: one
+  selector:
+    pods:
+      $namespace:
+        - $pod
+  loss:
+    loss: "100"
+    correlation: "100"
+  duration: "60m"

--- a/tests/integration/ha_tests/scripts/deploy_chaos_mesh.sh
+++ b/tests/integration/ha_tests/scripts/deploy_chaos_mesh.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+chaos_mesh_ns=$1
+chaos_mesh_version="2.4.1"
+
+if [ -z "${chaos_mesh_ns}" ]; then
+    exit 1
+fi
+
+deploy_chaos_mesh() {
+    if [ "$(helm repo list | grep 'chaos-mesh' | wc -l)" != "1" ]; then
+        echo "adding chaos-mesh helm repo"
+        helm repo add chaos-mesh https://charts.chaos-mesh.org
+    fi
+
+    echo "installing chaos-mesh"
+    helm install chaos-mesh chaos-mesh/chaos-mesh --namespace=${chaos_mesh_ns} --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/var/snap/microk8s/common/run/containerd.sock --set dashboard.create=false --version ${chaos_mesh_version} --set clusterScoped=false --set controllerManager.targetNamespace=${chaos_mesh_ns}
+    sleep 10
+}
+
+echo "namespace=${chaos_mesh_ns}"
+deploy_chaos_mesh

--- a/tests/integration/ha_tests/scripts/deploy_chaos_mesh.sh
+++ b/tests/integration/ha_tests/scripts/deploy_chaos_mesh.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Utility script to install chaosmesh in the K8S cluster, so test can use it to simulate
+# infrastructure failures
+
 chaos_mesh_ns=$1
 chaos_mesh_version="2.4.1"
 

--- a/tests/integration/ha_tests/scripts/destroy_chaos_mesh.sh
+++ b/tests/integration/ha_tests/scripts/destroy_chaos_mesh.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+chaos_mesh_ns=$1
+
+if [ -z "${chaos_mesh_ns}" ]; then
+    exit 1
+fi
+
+destroy_chaos_mesh() {
+    echo "deleting api-resources"
+    for i in $(kubectl api-resources | grep chaos-mesh | awk '{print $1}'); do timeout 30 kubectl delete ${i} --all --all-namespaces || :; done
+
+    if [ "$(kubectl -n ${chaos_mesh_ns} get mutatingwebhookconfiguration | grep 'choas-mesh-mutation' | wc -l)" = "1" ]; then
+        timeout 30 kubectl -n ${chaos_mesh_ns} delete mutatingwebhookconfiguration chaos-mesh-mutation || :
+    fi
+
+    if [ "$(kubectl -n ${chaos_mesh_ns} get validatingwebhookconfiguration | grep 'chaos-mesh-validation' | wc -l)" = "1" ]; then
+        timeout 30 kubectl -n ${chaos_mesh_ns} delete validatingwebhookconfiguration chaos-mesh-validation || :
+    fi
+
+    if [ "$(kubectl -n ${chaos_mesh_ns}) get validatingwebhookconfiguration | grep 'chaos-mesh-validate-auth' | wc -l)" = "1" ]; then
+        timeout 30 kubectl -n ${chaos_mesh_ns} delete validatingwebhookconfiguration chaos-mesh-validate-auth || :
+    fi
+
+    if [ "$(kubectl get clusterrolebinding | grep 'chaos-mesh' | awk '{print $1}' | wc -l)" != "0" ]; then
+        echo "deleting clusterrolebindings"
+        timeout 30 kubectl delete clusterrolebinding $(kubectl get clusterrolebinding | grep 'chaos-mesh' | awk '{print $1}') || :
+    fi
+
+    if [ "$(kubectl get clusterrole | grep 'chaos-mesh' | awk '{print $1}' | wc -l)" != "0" ]; then
+        echo "deleting clusterroles"
+        timeout 30 kubectl delete clusterrole $(kubectl get clusterrole | grep 'chaos-mesh' | awk '{print $1}') || :
+    fi
+
+    if [ "$(kubectl get crd | grep 'chaos-mesh.org' | awk '{print $1}' | wc -l)" != "0" ]; then
+        echo "deleting crds"
+        timeout 30 kubectl delete crd $(kubectl get crd | grep 'chaos-mesh.org' | awk '{print $1}') || :
+    fi
+
+    if [ -n "$chaos_mesh_ns" ] && [ "$(helm repo list --namespace $chaos_mesh_ns | grep 'chaos-mesh' | wc -l)" = "1" ]; then
+        echo "uninstalling chaos-mesh helm repo"
+        helm uninstall chaos-mesh --namespace ${chaos_mesh_ns} || :
+    fi
+}
+
+echo "Destroying chaos mesh in ${chaos_mesh_ns}"
+destroy_chaos_mesh

--- a/tests/integration/ha_tests/scripts/destroy_chaos_mesh.sh
+++ b/tests/integration/ha_tests/scripts/destroy_chaos_mesh.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# Utility script to removing chaosmesh from the K8S cluster, to clean up test artefacts
+
 chaos_mesh_ns=$1
 
 if [ -z "${chaos_mesh_ns}" ]; then

--- a/tests/integration/tls_tests/test_tls.py
+++ b/tests/integration/tls_tests/test_tls.py
@@ -31,7 +31,7 @@ async def test_build_and_deploy(ops_test: OpsTest) -> None:
         await ops_test.model.wait_for_idle(apps=[DATABASE_APP_NAME], status="active", timeout=2000)
 
         config = {"generate-self-signed-certificates": "true", "ca-common-name": "Test CA"}
-        await ops_test.model.deploy(TLS_CERTIFICATES_APP_NAME, channel="edge", config=config)
+        await ops_test.model.deploy(TLS_CERTIFICATES_APP_NAME, channel="beta", config=config)
         await ops_test.model.wait_for_idle(
             apps=[TLS_CERTIFICATES_APP_NAME], status="active", timeout=1000
         )

--- a/tox.ini
+++ b/tox.ini
@@ -38,7 +38,7 @@ description = Check code against coding style standards
 commands =
     poetry install --only fmt,lint
     poetry run codespell {[vars]lib_path}
-    poetry run codespell {toxinidir}/. --skip {toxinidir}/.git --skip {toxinidir}/.tox \
+    poetry run codespell {toxinidir} --skip {toxinidir}/.git --skip {toxinidir}/.tox \
         --skip {toxinidir}/build --skip {toxinidir}/lib --skip {toxinidir}/venv \
         --skip {toxinidir}/.mypy_cache --skip {toxinidir}/icon.svg
     # pflake8 wrapper supports config from pyproject.toml


### PR DESCRIPTION
# Issue
* Porting more of the HA VM tests to the K8S charm

# Solution
* Ported network cut and unique cluster DBs tests and necessary utility functions

# Context
* Most of the network cut test is based on similar work in the MySQL charm
* Tweaked how `deploy_and_scale_mongodb()` and `get_application_name()`, so to reuse them when deploying the second cluster and not to affect other tests in case the second cluster is already present
* Added a “cheat” pytest  cli parameter, so that `test_unique_cluster_dbs()` so that we don't necessarily need to repack the charm during `test_unique_cluster_dbs()` when testing locally against existing clusters


# Testing
* network cut test
* unique cluster DBs test

# Release Notes

