### PR TITLE
Adding full cluster crash/restart test

### DIFF
--- a/tests/integration/ha_tests/application_charm/src/continuous_writes.py
+++ b/tests/integration/ha_tests/application_charm/src/continuous_writes.py
@@ -24,12 +24,12 @@ def sigterm_handler(_signo, _stack_frame):
 
 def continous_writes(connection_string: str, starting_number: int):
     write_value = starting_number
+    client = MongoClient(
+        connection_string,
+        socketTimeoutMS=5000,
+    )
 
     while run:
-        client = MongoClient(
-            connection_string,
-            socketTimeoutMS=5000,
-        )
         db = client["continuous_writes_database"]
         test_collection = db["test_collection"]
         try:
@@ -50,11 +50,10 @@ def continous_writes(connection_string: str, starting_number: int):
             continue
         except PyMongoError as e:
             print(e)
-        finally:
-            client.close()
 
         write_value += 1
 
+    client.close()
     with open("/tmp/last_written_value", "w") as fd:
         fd.write(str(write_value - 1))
 

--- a/tests/integration/ha_tests/helpers.py
+++ b/tests/integration/ha_tests/helpers.py
@@ -1,6 +1,7 @@
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+import json
 import os
 import string
 import subprocess
@@ -8,7 +9,7 @@ import tempfile
 from asyncio import gather
 from datetime import datetime
 from pathlib import Path
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 import ops
 import yaml
@@ -70,7 +71,6 @@ async def scale_application(
     ops_test: OpsTest, application_name: str, desired_count: int, wait: bool = True
 ) -> None:
     """Scale a given application to the desired unit count.
-
     Args:
         ops_test: The ops test framework
         application_name: The name of the application
@@ -99,7 +99,6 @@ async def relate_mongodb_and_application(
     ops_test: OpsTest, mongodb_application_name: str, application_name: str
 ) -> None:
     """Relates the mongodb and application charms.
-
     Args:
         ops_test: The ops test framework
         mongodb_application_name: The mongodb charm application name
@@ -129,7 +128,6 @@ async def deploy_and_scale_mongodb(
     charm_path: Optional[Path] = None,
 ) -> str:
     """Deploys and scales the mongodb application charm.
-
     Args:
         ops_test: The ops test framework
         check_for_existing_application: Whether to check for existing mongodb applications
@@ -177,7 +175,6 @@ async def deploy_and_scale_mongodb(
 
 async def deploy_and_scale_application(ops_test: OpsTest) -> str:
     """Deploys and scales the test application charm.
-
     Args:
         ops_test: The ops test framework
     """
@@ -214,7 +211,6 @@ async def deploy_and_scale_application(ops_test: OpsTest) -> str:
 
 def is_relation_joined(ops_test: OpsTest, endpoint_one: str, endpoint_two: str) -> bool:
     """Check if a relation is joined.
-
     Args:
         ops_test: The ops test object passed into every test case
         endpoint_one: The first endpoint of the relation
@@ -231,7 +227,6 @@ async def get_process_pid(
     ops_test: OpsTest, unit_name: str, container_name: str, process: str
 ) -> int:
     """Return the pid of a process running in a given unit.
-
     Args:
         ops_test: The ops test object passed into every test case
         unit_name: The name of the unit
@@ -255,6 +250,8 @@ async def get_process_pid(
     ), f"Failed getting pid, unit={unit_name}, container={container_name}, process={process}"
 
     stripped_pid = pid.strip()
+    if not stripped_pid:
+        raise Exception()
     assert (
         stripped_pid
     ), f"Failed stripping pid, unit={unit_name}, container={container_name}, process={process}, {pid}"
@@ -266,7 +263,6 @@ async def send_signal_to_pod_container_process(
     ops_test: OpsTest, unit_name: str, container_name: str, process: str, signal_code: str
 ) -> None:
     """Send the specified signal to a pod container process.
-
     Args:
         ops_test: The ops test framework
         unit_name: The name of the unit to send signal to
@@ -333,7 +329,6 @@ async def count_primaries(ops_test: OpsTest) -> int:
 
 async def fetch_replica_set_members(ops_test: OpsTest) -> List[str]:
     """Fetches the hosts listed as replica set members in the MongoDB replica set configuration.
-
     Args:
         ops_test: reference to deployment.
     """

--- a/tests/integration/ha_tests/helpers.py
+++ b/tests/integration/ha_tests/helpers.py
@@ -255,8 +255,6 @@ async def get_process_pid(
     ), f"Failed getting pid, unit={unit_name}, container={container_name}, process={process}"
 
     stripped_pid = pid.strip()
-    if not stripped_pid:
-        raise Exception()
     assert (
         stripped_pid
     ), f"Failed stripping pid, unit={unit_name}, container={container_name}, process={process}, {pid}"

--- a/tests/integration/ha_tests/helpers.py
+++ b/tests/integration/ha_tests/helpers.py
@@ -1,6 +1,7 @@
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+import json
 import os
 import string
 import subprocess
@@ -8,7 +9,7 @@ import tempfile
 from asyncio import gather
 from datetime import datetime
 from pathlib import Path
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 import ops
 import yaml
@@ -649,3 +650,74 @@ async def wait_until_unit_in_status(
             assert member["stateStr"] == status, f"{unit_to_check.name} status is not {status}"
             return
     assert False, f"{unit_to_check.name} not found"
+
+
+async def update_pebble_plan(ops_test: OpsTest, override: Dict[str, str]) -> None:
+    """Injects a given override in mongod services and replans."""
+    layer = json.dumps({"services": {MONGODB_SERVICE_NAME: {"override": "merge", **override}}})
+    base_cmd = (
+        "ssh",
+        "--container",
+        MONGODB_CONTAINER_NAME,
+    )
+    now = datetime.now().isoformat()
+
+    for unit in ops_test.model.applications[APP_NAME].units:
+        echo_cmd = (
+            *base_cmd,
+            unit.name,
+            "echo",
+            f"'{layer}'",
+            ">",
+            "/ha_test.yaml",
+        )
+        ret_code, _, _ = await ops_test.juju(*echo_cmd)
+        assert ret_code == 0, f"Failed to create layer for {unit.name}"
+        add_plan_cmd = (
+            *base_cmd,
+            unit.name,
+            "/charm/bin/pebble",
+            "add",
+            # layer name label should be unique
+            f"ha_test_{now}",
+            "ha_test.yaml",
+        )
+        ret_code, _, _ = await ops_test.juju(*add_plan_cmd)
+        assert ret_code == 0, f"Failed to set pebble plan for unit {unit.name}"
+
+        replan_cmd = (
+            *base_cmd,
+            unit.name,
+            "/charm/bin/pebble",
+            "replan",
+        )
+        ret_code, _, _ = await ops_test.juju(*replan_cmd)
+        assert ret_code == 0, f"Failed to replan for unit {unit.name}"
+
+
+async def all_db_processes_down(ops_test: OpsTest) -> bool:
+    """Verifies that all units of the charm do not have the DB process running."""
+    app = await get_application_name(ops_test, APP_NAME)
+
+    try:
+        for attempt in Retrying(stop=stop_after_delay(60), wait=wait_fixed(3)):
+            with attempt:
+                for unit in ops_test.model.applications[app].units:
+                    search_db_process = (
+                        f"run --unit {unit.name} ps aux | grep {MONGOD_PROCESS_NAME}"
+                    )
+                    _, processes, _ = await ops_test.juju(*search_db_process.split())
+
+                    # `ps aux | grep {DB_PROCESS}` is a process on it's own and will be shown in
+                    # the output of ps aux, hence it it is important that we check if there is
+                    # more than one process containing the name `DB_PROCESS`
+                    # splitting processes by "\n" results in one or more empty lines, hence we
+                    # need to process these lines accordingly.
+                    processes = [proc for proc in processes.split("\n") if len(proc) > 0]
+
+                    if len(processes) > 1:
+                        raise ProcessRunningError
+    except RetryError:
+        return False
+
+    return True

--- a/tests/integration/ha_tests/helpers.py
+++ b/tests/integration/ha_tests/helpers.py
@@ -605,6 +605,7 @@ def isolate_instance_from_cluster(ops_test: OpsTest, unit_name: str) -> None:
         with open(
             "tests/integration/ha_tests/manifests/chaos_network_loss.yml", "r"
         ) as chaos_network_loss_file:
+            # Generates a manifest for chaosmesh to simulate a network failure for a pod
             template = string.Template(chaos_network_loss_file.read())
             chaos_network_loss = template.substitute(
                 namespace=ops_test.model.info.name,

--- a/tests/integration/ha_tests/helpers.py
+++ b/tests/integration/ha_tests/helpers.py
@@ -605,7 +605,6 @@ def isolate_instance_from_cluster(ops_test: OpsTest, unit_name: str) -> None:
         with open(
             "tests/integration/ha_tests/manifests/chaos_network_loss.yml", "r"
         ) as chaos_network_loss_file:
-            # Generates a manifest for chaosmesh to simulate a network failure for a pod
             template = string.Template(chaos_network_loss_file.read())
             chaos_network_loss = template.substitute(
                 namespace=ops_test.model.info.name,

--- a/tests/integration/ha_tests/helpers.py
+++ b/tests/integration/ha_tests/helpers.py
@@ -1,7 +1,6 @@
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-import json
 import os
 import string
 import subprocess
@@ -9,7 +8,7 @@ import tempfile
 from asyncio import gather
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import List, Optional
 
 import ops
 import yaml
@@ -71,6 +70,7 @@ async def scale_application(
     ops_test: OpsTest, application_name: str, desired_count: int, wait: bool = True
 ) -> None:
     """Scale a given application to the desired unit count.
+
     Args:
         ops_test: The ops test framework
         application_name: The name of the application
@@ -99,6 +99,7 @@ async def relate_mongodb_and_application(
     ops_test: OpsTest, mongodb_application_name: str, application_name: str
 ) -> None:
     """Relates the mongodb and application charms.
+
     Args:
         ops_test: The ops test framework
         mongodb_application_name: The mongodb charm application name
@@ -128,6 +129,7 @@ async def deploy_and_scale_mongodb(
     charm_path: Optional[Path] = None,
 ) -> str:
     """Deploys and scales the mongodb application charm.
+
     Args:
         ops_test: The ops test framework
         check_for_existing_application: Whether to check for existing mongodb applications
@@ -175,6 +177,7 @@ async def deploy_and_scale_mongodb(
 
 async def deploy_and_scale_application(ops_test: OpsTest) -> str:
     """Deploys and scales the test application charm.
+
     Args:
         ops_test: The ops test framework
     """
@@ -211,6 +214,7 @@ async def deploy_and_scale_application(ops_test: OpsTest) -> str:
 
 def is_relation_joined(ops_test: OpsTest, endpoint_one: str, endpoint_two: str) -> bool:
     """Check if a relation is joined.
+
     Args:
         ops_test: The ops test object passed into every test case
         endpoint_one: The first endpoint of the relation
@@ -227,6 +231,7 @@ async def get_process_pid(
     ops_test: OpsTest, unit_name: str, container_name: str, process: str
 ) -> int:
     """Return the pid of a process running in a given unit.
+
     Args:
         ops_test: The ops test object passed into every test case
         unit_name: The name of the unit
@@ -263,6 +268,7 @@ async def send_signal_to_pod_container_process(
     ops_test: OpsTest, unit_name: str, container_name: str, process: str, signal_code: str
 ) -> None:
     """Send the specified signal to a pod container process.
+
     Args:
         ops_test: The ops test framework
         unit_name: The name of the unit to send signal to
@@ -329,6 +335,7 @@ async def count_primaries(ops_test: OpsTest) -> int:
 
 async def fetch_replica_set_members(ops_test: OpsTest) -> List[str]:
     """Fetches the hosts listed as replica set members in the MongoDB replica set configuration.
+
     Args:
         ops_test: reference to deployment.
     """

--- a/tests/integration/ha_tests/helpers.py
+++ b/tests/integration/ha_tests/helpers.py
@@ -703,9 +703,7 @@ async def all_db_processes_down(ops_test: OpsTest) -> bool:
         for attempt in Retrying(stop=stop_after_delay(60), wait=wait_fixed(3)):
             with attempt:
                 for unit in ops_test.model.applications[app].units:
-                    search_db_process = (
-                        f"run --unit {unit.name} ps aux | grep {MONGOD_PROCESS_NAME}"
-                    )
+                    search_db_process = f"run --unit {unit.name} pgrep -x {MONGOD_PROCESS_NAME}"
                     _, processes, _ = await ops_test.juju(*search_db_process.split())
 
                     # `ps aux | grep {DB_PROCESS}` is a process on it's own and will be shown in

--- a/tests/integration/ha_tests/test_ha.py
+++ b/tests/integration/ha_tests/test_ha.py
@@ -444,7 +444,7 @@ async def test_full_cluster_crash(ops_test: OpsTest, restart_policy, continuous_
     assert set(member_hosts) == set(hostnames)
     assert (
         await count_primaries(ops_test) == 1
-    ), "there are more than one primary in the replica set."
+    ), "there is more than one primary in the replica set."
 
     # verify that no writes to the db were missed
     await verify_writes(ops_test)


### PR DESCRIPTION
# Cluster crash test failures:
Cluster crash/restart currently fail the assertion for total writes, meaning that the DB didn't persist some of the writes `continuous_writes.py` thinks it should have.

The cause for the mismatch seems to be a PyMongo OperationError thrown while restarted nodes rejoin the cluster with the following message:
```
No keys found for HMAC that is valid for time: { ts: Timestamp(1669922958, 10) } with id: 7172123513443057669, full error: {'ok': 0.0, 'errmsg': 'No keys found for HMAC that is valid for time: { ts: Timestamp(1669922958, 10) } with id: 7172123513443057669', 'code': 211, 'codeName': 'KeyNotFound'}
```

## Steps to reproduce manually
* Deploy a cluster of three mongodb-k8s units
* Deploy the HA test charm from /tests/integration/ha_tests/application_charm
* Create a layer configuration to prevent pebble from restarting the service and upload it to the MongoDB units in the mongod container:
```
services:
  mongod:
    override: merge
    on-success: ignore
    on-failure: ignore
```
* Add the layer to pebble and replan:
```
/charm/bin/pebble add test2 <your_layer_config_location>
/charm/bin/pebble replan
```
* Kill all mongod processes in all the units
* Replan the services to restart them and check the output of `continuous_writes.py`. You should get errors about the time the second or third node rejoins.

## Potentially related log output from mongod logs:
```
2022-12-01T11:32:55.643Z [mongod] {"t":{"$date":"2022-12-01T11:32:55.643+00:00"},"s":"I",  "c":"-",
  "id":4939300, "ctx":"monitoring-keys-for-HMAC","msg":"Failed to refresh key cache","attr":{"error":"ReadConcernMajorityNotAvailableYet: Read concern majority reads are currently not possible.","nextWakeupMillis":600}}
```
```
2022-12-01T13:37:22.043Z [mongod] {"t":{"$date":"2022-12-01T13:37:22.042+00:00"},"s":"I",  "c":"CONTROL",  "id":20714,   "ctx":"LogicalSessionCacheRefresh","msg":"Failed to refresh session cache, will try again at the next refresh interval","attr":{"error":"NotYetInitialized: Replication has not yet been configured"}}
```

## Potentially related issues:
* [Same error, but seems to be for older MongoDB versions](https://jira.mongodb.org/browse/SERVER-47568)
* [Same error, more recent version](https://stackoverflow.com/questions/70518350/mongodb-replicaset-failed-to-refresh-key-cache)
* [Same error while changing storage engine](https://www.mongodb.com/community/forums/t/adding-wiredtiger-node-to-mmapv1-replica-set-leads-to-no-keys-found-for-hmac/5167)
* [Same error while trying to convert cluster to replicaset](https://stackoverflow.com/questions/60876115/error-while-converting-a-mongodb-cluster-into-a-replica-set/65909771#65909771)
