### PR TITLE
Copying over deployment guide from MongoDB-k8s

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,42 +16,44 @@ This operator charm deploys and operates MongoDB on Kubernetes. It offers featur
 
 ## Config options
 auto-delete - `boolean`; When a relation is removed, auto-delete ensures that any relevant databases
-associated with the relation are also removed. Set with `juju config mongodb auto-delete=<bool>`.
+associated with the relation are also removed. Set with `juju config mongodb-k8s auto-delete=<bool>`.
 
-admin-password - `string`; The password for the database admin user. Set with `juju run-action mongodb/leader set-admin-password --wait`
+admin-password - `string`; The password for the database admin user. Set with `juju run-action mongodb-k8s/leader set-admin-password --wait`
 
-tls external key - `string`; TLS external key for encryption outside the cluster. Set with `juju run-action mongodb/0 set-tls-private-key "external-key=$(base64 -w0 external-key-0.pem)" --wait`
+tls external key - `string`; TLS external key for encryption outside the cluster. Set with `juju run-action mongodb-k8s/0 set-tls-private-key "external-key=$(base64 -w0 external-key-0.pem)" --wait`
 
-tls internal key - `string`;  TLS external key for encryption inside the cluster. Set with `juju run-action mongodb/0 set-tls-private-key "internal-key=$(base64 -w0 internal-key.pem)"  --wait`
-
+tls internal key - `string`;  TLS external key for encryption inside the cluster. Set with `juju run-action mongodb-k8s/0 set-tls-private-key "internal-key=$(base64 -w0 internal-key.pem)"  --wait`
 
 ## Usage
 
-Create a Juju model for your operators, say "lma"
+### Basic Usage
+To deploy a single unit of MongoDB using its default configuration
+```shell
+juju deploy ./mongodb-k8s_ubuntu-20.04-amd64.charm --resource mongodb-image=mongo:4.4
+```
 
-    juju add-model lma
+It is customary to use MongoDB with replication. Hence usually more than one unit (preferably an odd number to prohibit a "split-brain" scenario) is deployed. To deploy MongoDB with multiple replicas, specify the number of desired units with the `-n` option.
+```shell
+juju deploy ./mongodb-k8s_ubuntu-20.04-amd64.charm --resource mongodb-image=mongo:4.4
+ -n <number_of_replicas>
+```
 
-Deploy a single unit of MongoDB using its default configuration
+### Replication
+#### Adding Replicas
+To add more replicas one can use the `juju scale-application` functionality i.e.
+```shell
+juju scale-application mongodb-k8s -n <num_of_replicas_to_add>
+```
+The implementation of `add-unit` allows the operator to add more than one unit, but functions internally by adding one replica at a time, as specified by the [constraints](https://www.mongodb.com/docs/manual/reference/command/replSetReconfig/#reconfiguration-can-add-or-remove-no-more-than-one-voting-member-at-a-time) of MongoDB.
 
-    juju deploy ./mongodb-k8s_ubuntu-20.04-amd64.charm --resource mongodb-image=mongo:4.4
 
-It is customary to use MongoDB with replication. Hence usually more
-than one unit (preferably and odd number) is deployed. Additionally
-units (say two more) may be deployed using
+#### Removing Replicas 
+Similarly to scale down the number of replicas the `juju scale-application` functionality may be used i.e.
+```shell
+juju scale-application mongodb-k8s -n <desired number of units>
+```
+The implementation of `remove-unit` allows the operator to remove more than one replica so long has the operator **does not remove a majority of the replicas**. The functionality of `remove-unit` functions by removing one replica at a time, as specified by the [constraints](https://www.mongodb.com/docs/manual/reference/command/replSetReconfig/#reconfiguration-can-add-or-remove-no-more-than-one-voting-member-at-a-time) of MongoDB.
 
-    juju add-unit -n 2 mongodb
-
-Alternatively multiple MongoDB units may be deployed at the
-outset. This is usually faster
-
-    juju deploy -n 3 ./mongodb-k8s_ubuntu-20.04-amd64.charm --resource mongodb-image=mongo:4.4
-
-If required, remove the deployed monitoring model completely
-
-    juju destroy-model -y lma --no-wait --force --destroy-storage
-
-Note the `--destroy-storage` will delete any data stored by MongoDB in
-its persistent store.
 
 ## Relations
 
@@ -59,15 +61,15 @@ Supported [relations](https://juju.is/docs/olm/relations):
 
 #### `mongodb_client` interface:
 
-Relations to new applications are supported via the `mongodb_client` interface. To create a relation: 
+Relations to applications are supported via the `mongodb_client` interface. To create a relation: 
 
 ```shell
-juju relate mongodb application
+juju relate mongodb-k8s application
 ```
 
 To remove a relation:
 ```shell
-juju remove-relation mongodb application
+juju remove-relation mongodb-k8s application
 ```
 
 #### `tls` interface:
@@ -79,17 +81,69 @@ We have also supported TLS for the MongoDB k8s charm. To enable TLS:
 juju deploy tls-certificates-operator --channel=edge
 # add the necessary configurations for TLS
 juju config tls-certificates-operator generate-self-signed-certificates="true" ca-common-name="Test CA" 
-# enable TLS via relation
-juju relate tls-certificates-operator mongodb
-# disable TLS by removing relation
-juju remove-relation mongodb tls-certificates-operator
+# to enable TLS relate the two applications 
+juju relate tls-certificates-operator mongodb-k8s 
+```
+
+Updates to private keys for certificate signing requests (CSR) can be made via the `set-tls-private-key` action. Note passing keys to external/internal keys should *only be done with* `base64 -w0` *not* `cat`. With three replicas this schema should be followed:
+```shell
+# generate shared internal key
+openssl genrsa -out internal-key.pem 3072
+# generate external keys for each unit
+openssl genrsa -out external-key-0.pem 3072
+openssl genrsa -out external-key-1.pem 3072
+openssl genrsa -out external-key-2.pem 3072
+# apply both private keys on each unit, shared internal key will be allied only on juju leader
+juju run-action mongodb-k8s /0 set-tls-private-key "external-key=$(base64 -w0 external-key-0.pem)"  "internal-key=$(base64 -w0 internal-key.pem)"  --wait
+juju run-action mongodb-k8s /1 set-tls-private-key "external-key=$(base64 -w0 external-key-1.pem)"  "internal-key=$(base64 -w0 internal-key.pem)"  --wait
+juju run-action mongodb-k8s /2 set-tls-private-key "external-key=$(base64 -w0 external-key-2.pem)"  "internal-key=$(base64 -w0 internal-key.pem)"  --wait
+
+# updates can also be done with auto-generated keys with
+juju run-action mongodb-k8s /0 set-tls-private-key --wait
+juju run-action mongodb-k8s /1 set-tls-private-key --wait
+juju run-action mongodb-k8s /2 set-tls-private-key --wait
+```
+
+To disable TLS remove the relation
+```shell
+juju remove-relation mongodb-k8s  tls-certificates-operator
 ```
 
 Note: The TLS settings here are for self-signed-certificates which are not recommended for production clusters, the `tls-certificates-operator` charm offers a variety of configurations, read more on the TLS charm [here](https://charmhub.io/tls-certificates-operator)
 
+### Password rotation
+#### Internal admin user
+The admin user is used internally by the Charmed MongoDB Operator, the `set-password` action can be used to rotate its password.
+```shell
+# to set a specific password for the admin user
+juju run-action mongodb-k8s/leader set-password password=<password> --wait
+
+# to randomly generate a password for the admin user
+juju run-action mongodb-k8s/leader set-password --wait
+```
+
+#### Related applications users
+To rotate the passwords of users created for related applications, the relation should be removed and related again. That process will generate a new user and password for the application.
+```shell
+juju remove-relation application mongodb-k8s 
+juju add-relation application mongodb-k8s 
+```
+
+## Security
+Security issues in the Charmed MongoDB Operator can be reported through [LaunchPad](https://wiki.ubuntu.com/DebuggingSecurity#How%20to%20File). Please do not file GitHub issues about security issues.
+
 
 ## Contributing
 
-Please see the [Juju SDK docs](https://juju.is/docs/sdk) for guidelines on enhancements to this
-charm following best practice guidelines, and [CONTRIBUTING.md](./CONTRIBUTING.md) for developer guidance.
+Please see the [Juju SDK docs](https://juju.is/docs/sdk) for guidelines on enhancements to this charm following best practice guidelines, and [CONTRIBUTING.md](https://github.com/canonical/mongodb-operator/blob/main/CONTRIBUTING.md) for developer guidance.
 
+
+## License
+The Charmed MongoDB Operator is free software, distributed under the Apache Software License, version 2.0. See [LICENSE](https://github.com/canonical/mongodb-operator/blob/main/LICENSE) for more information.
+
+The Charmed MongoDB Operator is free software, distributed under the Apache Software License, version 2.0. It [installs/operates/depends on] [MongoDB Community Version](https://github.com/mongodb/mongo), which is licensed under the Server Side Public License (SSPL)
+
+See [LICENSE](https://github.com/canonical/mongodb-operator/blob/main/LICENSE) for more information.
+
+## Trademark notice
+MongoDB' is a trademark or registered trademark of MongoDB Inc. Other trademarks are property of their respective owners.


### PR DESCRIPTION
Copied over deployment guide from MongoDB-K8s ; and then added `-k8s` to the application name.

This deployment guide has already been reviewed and doesn't need a re-review.