### PR TITLE
Fix data directory permissions with chown

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -15,6 +15,7 @@ from typing import Dict, Optional
 
 from charms.mongodb.v0.helpers import (
     CONF_DIR,
+    DATA_DIR,
     KEY_FILE,
     TLS_EXT_CA_FILE,
     TLS_EXT_PEM_FILE,
@@ -46,7 +47,6 @@ MONITOR_PRIVILEGES = {
     "resource": {"db": "", "collection": ""},
     "actions": ["listIndexes", "listCollections", "dbStats", "dbHash", "collStats", "find"],
 }
-DATA_DIR = "/var/lib/mongodb"
 UNIX_USER = "mongodb"
 UNIX_GROUP = "mongodb"
 
@@ -379,10 +379,10 @@ class MongoDBCharm(CharmBase):
             )
 
     def _fix_data_dir(self, container: Container) -> None:
-        """
-        Ensure the data directory for mongodb is writable for the "mongodb" user.
-        
-        Until the ability to set fsGroup and fsGroupChangePolicy via Pod securityContext is available we fix permissions incorrectly with chown.
+        """Ensure the data directory for mongodb is writable for the "mongodb" user.
+
+        Until the ability to set fsGroup and fsGroupChangePolicy via Pod securityContext
+        is available we fix permissions incorrectly with chown.
         """
         paths = container.list_files(DATA_DIR, itself=True)
         assert len(paths) == 1, "list_files doesn't return only directory itself"

--- a/src/charm.py
+++ b/src/charm.py
@@ -379,8 +379,11 @@ class MongoDBCharm(CharmBase):
             )
 
     def _fix_data_dir(self, container: Container) -> None:
-        # Fix permissions incorrectly with chown.
-        # Wait for the ability to set fsGroup and fsGroupChangePolicy via Pod securityContext
+        """
+        Ensure the data directory for mongodb is writable for the "mongodb" user.
+        
+        Until the ability to set fsGroup and fsGroupChangePolicy via Pod securityContext is available we fix permissions incorrectly with chown.
+        """
         paths = container.list_files(DATA_DIR, itself=True)
         assert len(paths) == 1, "list_files doesn't return only directory itself"
         logger.debug(f"Data directory ownership: {paths[0].user}:{paths[0].group}")

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -44,7 +44,8 @@ class TestCharm(unittest.TestCase):
         self.addCleanup(self.harness.cleanup)
 
     @patch("ops.framework.EventBase.defer")
-    def test_mongod_pebble_ready(self, defer):
+    @patch("charm.MongoDBCharm._fix_data_dir")
+    def test_mongod_pebble_ready(self, fix_data_dir, defer):
         # Expected plan after Pebble ready with default config
         expected_plan = {
             "services": {

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -5,6 +5,7 @@ import unittest
 from unittest import mock
 from unittest.mock import patch
 
+from charms.mongodb.v0.helpers import CONF_DIR, DATA_DIR, KEY_FILE
 from ops.model import ActiveStatus, ModelError
 from ops.pebble import APIError, ExecError, PathError, ProtocolError
 from ops.testing import Harness
@@ -57,9 +58,9 @@ class TestCharm(unittest.TestCase):
                     "command": (
                         "mongod --bind_ip_all "
                         "--replSet=mongodb-k8s "
-                        "--dbpath=/var/lib/mongodb --auth "
+                        f"--dbpath={DATA_DIR} --auth "
                         "--clusterAuthMode=keyFile "
-                        "--keyFile=/etc/mongod/keyFile \n"
+                        f"--keyFile={CONF_DIR}/{KEY_FILE} \n"
                     ),
                     "startup": "enabled",
                 }


### PR DESCRIPTION
The data directory is not always writable for the "mongodb" user (e.g. on GKE).
Unfortunately, right now, juju/operator-framework doesn't allow set fsGroup and fsGroupChangePolicy via Pod securityContext.
So it is necessary to change data directory ownership via the "chown" cmd.