### PR TITLE
fix(typo): Rename eporter to exporter

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -140,7 +140,7 @@ class MongoDBCharm(CharmBase):
         # Restart changed services and start startup-enabled services.
         container.replan()
 
-        # when a network cuts and the pod restarts - reconnect to the eporter
+        # when a network cuts and the pod restarts - reconnect to the exporter
         self._connect_mongodb_exporter()
 
         # TODO: rework status


### PR DESCRIPTION
I was reading the code and just noticed there's a typo in a comment. This fixes it and reassures devs that it is good to use comments - people do read them.

tl;dr s/eporter/exporter/