### PR TITLE
[DPE-2048] Stabilize HA tests

### DIFF
--- a/tests/integration/cleanup_resources.py
+++ b/tests/integration/cleanup_resources.py
@@ -6,10 +6,11 @@ import argparse
 import json
 import os
 import subprocess
-
+import logging
+logger = logging.getLogger(__name__)
 
 def cleanup_chaos_mesh(namespace) -> None:
-    print(f"Cleaning up chaos mesh in {namespace}")
+    logger.info(f"Cleaning up chaos mesh in {namespace}")
     env = os.environ
     env["KUBECONFIG"] = os.path.expanduser("~/.kube/config")
 
@@ -18,16 +19,16 @@ def cleanup_chaos_mesh(namespace) -> None:
         shell=True,
         env=env,
     )
+    logger.info("Destroy chaos mesh output:")
     for line in output.decode("utf-8").splitlines():
-        print(line)
+        logger.info(line)
 
 
 def cleanup_juju_models() -> None:
     for model in _filter_tests_models("admin/test-"):
-        print(f"Destroying model {model}")
+        logger.info(f"Destroying model {model}")
         delete_cmd = ["juju", "destroy-model", model, "--destroy-storage", "-y"]
-        subprocess.check_output(delete_cmd).decode("utf-8")
-
+        subprocess.check_output(delete_cmd)
 
 def cleanup_all(namespace: str) -> None:
     cleanup_chaos_mesh(namespace)

--- a/tests/integration/cleanup_resources.py
+++ b/tests/integration/cleanup_resources.py
@@ -1,0 +1,63 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+
+import argparse
+import json
+import os
+import subprocess
+
+
+def cleanup_chaos_mesh(namespace) -> None:
+    print(f"Cleaning up chaos mesh in {namespace}")
+    env = os.environ
+    env["KUBECONFIG"] = os.path.expanduser("~/.kube/config")
+
+    output = subprocess.check_output(
+        f"tests/integration/ha_tests/scripts/destroy_chaos_mesh.sh {namespace}",
+        shell=True,
+        env=env,
+    )
+    for line in output.decode("utf-8").splitlines():
+        print(line)
+
+
+def cleanup_juju_models() -> None:
+    for model in _filter_tests_models("admin/test-"):
+        print(f"Destroying model {model}")
+        delete_cmd = ["juju", "destroy-model", model, "--destroy-storage", "-y"]
+        subprocess.check_output(delete_cmd).decode("utf-8")
+
+
+def cleanup_all(namespace: str) -> None:
+    cleanup_chaos_mesh(namespace)
+    cleanup_juju_models()
+
+
+def _filter_tests_models(prefix: str):
+    cmd = ["juju", "models", "--format", "json"]
+    models_str = subprocess.check_output(cmd).decode("utf-8")
+
+    models = json.loads(models_str)["models"]
+
+    filtered_models = [model["name"] for model in models if model["name"].startswith(prefix)]
+    return filtered_models
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Cleanup script")
+    parser.add_argument("--namespace", help="The k8s namespace to cleanup")
+    parser.add_argument(
+        "--cleanup",
+        choices=["cleanup_after_ha", "juju_models", "all"],
+        help="The type of cleanup to perform",
+    )
+
+    args = parser.parse_args()
+
+    if args.cleanup == "cleanup_chaos_mesh":
+        cleanup_chaos_mesh(args.namespace)
+    elif args.cleanup == "juju_models":
+        cleanup_juju_models()
+    elif args.cleanup == "all":
+        cleanup_all(args.namespace)

--- a/tests/integration/cleanup_resources.py
+++ b/tests/integration/cleanup_resources.py
@@ -4,10 +4,12 @@
 
 import argparse
 import json
+import logging
 import os
 import subprocess
-import logging
+
 logger = logging.getLogger(__name__)
+
 
 def cleanup_chaos_mesh(namespace) -> None:
     logger.info(f"Cleaning up chaos mesh in {namespace}")
@@ -29,6 +31,7 @@ def cleanup_juju_models() -> None:
         logger.info(f"Destroying model {model}")
         delete_cmd = ["juju", "destroy-model", model, "--destroy-storage", "-y"]
         subprocess.check_output(delete_cmd)
+
 
 def cleanup_all(namespace: str) -> None:
     cleanup_chaos_mesh(namespace)

--- a/tests/integration/ha_tests/helpers.py
+++ b/tests/integration/ha_tests/helpers.py
@@ -259,7 +259,7 @@ async def get_process_pid(
         return_code == 0
     ), f"Failed getting pid, unit={unit_name}, container={container_name}, process={process}"
 
-    stripped_pid = pid.strip().replace('\r', '').replace('\n', '')
+    stripped_pid = pid.strip().replace("\r", "").replace("\n", "")
     assert (
         stripped_pid
     ), f"Failed stripping pid, unit={unit_name}, container={container_name}, process={process}, {pid}"
@@ -675,13 +675,14 @@ async def retrieve_current_mongod_command(ops_test: OpsTest, unit_name) -> str:
         "cat",
         f"/proc/{pid}/cmdline",
     ]
-    
+
     return_code, mongod_cmd, _ = await ops_test.juju(*get_cmd_command)
-    assert len(mongod_cmd) > 0, f"Failed getting CMD, unit={unit_name}, container={MONGODB_CONTAINER_NAME}, pid={pid}, return_code={return_code}"
+    assert (
+        len(mongod_cmd) > 0
+    ), f"Failed getting CMD, unit={unit_name}, container={MONGODB_CONTAINER_NAME}, pid={pid}, return_code={return_code}"
     assert (
         return_code == 0
     ), f"Failed getting CMD, unit={unit_name}, container={MONGODB_CONTAINER_NAME}, pid={pid}, return_code={return_code}"
-
 
     return mongod_cmd.replace("--", " --")
 

--- a/tests/integration/ha_tests/helpers.py
+++ b/tests/integration/ha_tests/helpers.py
@@ -259,7 +259,7 @@ async def get_process_pid(
         return_code == 0
     ), f"Failed getting pid, unit={unit_name}, container={container_name}, process={process}"
 
-    stripped_pid = pid.strip()
+    stripped_pid = pid.strip().replace('\r', '').replace('\n', '')
     assert (
         stripped_pid
     ), f"Failed stripping pid, unit={unit_name}, container={container_name}, process={process}, {pid}"
@@ -667,43 +667,23 @@ async def wait_until_unit_in_status(
 async def retrieve_current_mongod_command(ops_test: OpsTest, unit_name) -> str:
     pid = await get_process_pid(ops_test, unit_name, MONGODB_CONTAINER_NAME, MONGOD_PROCESS_NAME)
 
-    # client = kubernetes.client.api.core_v1_api.CoreV1Api()
-
-    # response = kubernetes.stream.stream(
-    #     client.connect_get_namespaced_pod_exec,
-    #     pod_name,
-    #     ops_test.model.info.name,
-    #     container=MONGODB_CONTAINER_NAME,
-    #     command=f"ps -o fp {pid}",
-    #     stdin=False,
-    #     stdout=True,
-    #     stderr=True,
-    #     tty=False,
-    #     _preload_content=False,
-    # )
-
     get_cmd_command = [
         "ssh",
         "--container",
         MONGODB_CONTAINER_NAME,
         unit_name,
-        "ps",
-        "-o",
-        "cmd",
-        "fp",
-        pid,
+        "cat",
+        f"/proc/{pid}/cmdline",
     ]
-    # This gives us a truncated output of the entire output
-    # - this is the last thing that is needed to solve this.
+    
     return_code, mongod_cmd, _ = await ops_test.juju(*get_cmd_command)
-
+    assert len(mongod_cmd) > 0, f"Failed getting CMD, unit={unit_name}, container={MONGODB_CONTAINER_NAME}, pid={pid}, return_code={return_code}"
     assert (
         return_code == 0
-    ), f"Failed getting CMD, unit={unit_name}, container={MONGODB_CONTAINER_NAME}, pid={pid}"
+    ), f"Failed getting CMD, unit={unit_name}, container={MONGODB_CONTAINER_NAME}, pid={pid}, return_code={return_code}"
 
-    stripped_pid = mongod_cmd.split("\n")
-    assert len(stripped_pid) > 1, f"no CMD for pid={pid}"
-    return stripped_pid[1]
+
+    return mongod_cmd.replace("--", " --")
 
 
 async def update_pebble_plans(ops_test: OpsTest, override: Dict[str, str]) -> None:

--- a/tests/integration/ha_tests/scripts/destroy_chaos_mesh.sh
+++ b/tests/integration/ha_tests/scripts/destroy_chaos_mesh.sh
@@ -11,17 +11,20 @@ fi
 destroy_chaos_mesh() {
     echo "deleting api-resources"
     for i in $(kubectl api-resources | grep chaos-mesh | awk '{print $1}'); do timeout 30 kubectl delete ${i} --all --all-namespaces || :; done
-
+    
     if [ "$(kubectl -n ${chaos_mesh_ns} get mutatingwebhookconfiguration | grep 'choas-mesh-mutation' | wc -l)" = "1" ]; then
+        echo "deleting chaos-mesh-mutation"    
         timeout 30 kubectl -n ${chaos_mesh_ns} delete mutatingwebhookconfiguration chaos-mesh-mutation || :
     fi
 
-    if [ "$(kubectl -n ${chaos_mesh_ns} get validatingwebhookconfiguration | grep 'chaos-mesh-validation' | wc -l)" = "1" ]; then
-        timeout 30 kubectl -n ${chaos_mesh_ns} delete validatingwebhookconfiguration chaos-mesh-validation || :
+    if [ "$(kubectl -n ${chaos_mesh_ns} get validatingwebhookconfiguration | grep 'chaos-mesh-validation-auth' | wc -l)" = "1" ]; then
+        echo "deleting chaos-mesh-validation-auth"
+        timeout 30 kubectl -n ${chaos_mesh_ns} delete validatingwebhookconfiguration chaos-mesh-validation-auth || :
     fi
 
-    if [ "$(kubectl -n ${chaos_mesh_ns}) get validatingwebhookconfiguration | grep 'chaos-mesh-validate-auth' | wc -l)" = "1" ]; then
-        timeout 30 kubectl -n ${chaos_mesh_ns} delete validatingwebhookconfiguration chaos-mesh-validate-auth || :
+    if [ "$(kubectl -n ${chaos_mesh_ns} get validatingwebhookconfiguration | grep 'chaos-mesh-validation' | wc -l)" = "1" ]; then
+        echo 'deleting chaos-mesh-validation'
+        timeout 30 kubectl -n ${chaos_mesh_ns} delete validatingwebhookconfiguration chaos-mesh-validation || :
     fi
 
     if [ "$(kubectl get clusterrolebinding | grep 'chaos-mesh' | awk '{print $1}' | wc -l)" != "0" ]; then

--- a/tox.ini
+++ b/tox.ini
@@ -119,3 +119,14 @@ commands_pre =
     poetry run pip install juju==2.9.42.1
 commands =
     poetry run pytest -v --tb native --log-cli-level=INFO -s --durations=0 {posargs} {[vars]tests_path}/integration/relation_tests/test_charm_relations.py
+
+[testenv:cleanup_chaos_mesh]
+description = Cleanup chaos mesh
+commands =
+     python {[vars]tests_path}/integration/cleanup_resources.py --cleanup "cleanup_chaos_mesh" --namespace "{posargs}" 
+
+[testenv:cleanup_juju_models]
+description = Cleanup Juju models
+commands =
+    python {[vars]tests_path}/integration/cleanup_resources.py --cleanup "juju_models"
+    


### PR DESCRIPTION
* Fix the HA tests by replacing  a command to get MongoDB start arguments.
 "ps -o cmd fp" command id replaced to  "cat /proc/{pid}/cmdline" because the
former one was truncating long output string.

* Update bash script to cleanup chaos mesh used in HA testing
* Add scripts for cleanup resources.

