### PR TITLE
[DPE-2156] Rename keys for user's secrets to be compatible with juju 3.1

### DIFF
--- a/lib/charms/mongodb/v0/users.py
+++ b/lib/charms/mongodb/v0/users.py
@@ -70,7 +70,7 @@ class _OperatorUser(MongoDBUser):
     """Operator user for MongoDB."""
 
     _username = "operator"
-    _password_key_name = f"{_username}_password"
+    _password_key_name = f"{_username}-password"
     _database_name = "admin"
     _roles = ["default"]
     _hosts = []
@@ -80,7 +80,7 @@ class _MonitorUser(MongoDBUser):
     """Monitor user for MongoDB."""
 
     _username = "monitor"
-    _password_key_name = f"{_username}_password"
+    _password_key_name = f"{_username}-password"
     _database_name = ""
     _roles = ["monitor"]
     _privileges = {
@@ -95,7 +95,7 @@ class _BackupUser(MongoDBUser):
     """Backup user for MongoDB."""
 
     _username = "backup"
-    _password_key_name = f"{_username}_password"
+    _password_key_name = f"{_username}-password"
     _database_name = ""
     _roles = ["backup"]
     _mongodb_role = "pbmAnyAction"

--- a/src/charm.py
+++ b/src/charm.py
@@ -469,10 +469,10 @@ class MongoDBCharm(CharmBase):
     # BEGIN: helper functions
 
     def _is_user_created(self, user: MongoDBUser) -> bool:
-        return f"{user.get_username()}_user_created" in self.app_peer_data
+        return f"{user.get_username()}-user-created" in self.app_peer_data
 
     def _set_user_created(self, user: MongoDBUser) -> None:
-        self.app_peer_data[f"{user.get_username()}_user_created"] = "True"
+        self.app_peer_data[f"{user.get_username()}-user-created"] = "True"
 
     def _get_mongodb_config_for_user(
         self, user: MongoDBUser, hosts: list[str]

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -603,7 +603,7 @@ class TestCharm(unittest.TestCase):
         self.harness.charm.on.start.emit()
 
         # verify app data
-        self.assertEqual("operator_user_created" in self.harness.charm.app_peer_data, True)
+        self.assertEqual("operator-user-created" in self.harness.charm.app_peer_data, True)
         defer.assert_called()
 
         # the second call to init user should fail if "exec" is called, but shouldn't happen
@@ -645,7 +645,7 @@ class TestCharm(unittest.TestCase):
         container = self.harness.model.unit.get_container("mongod")
         self.harness.set_can_connect(container, True)
         self.harness.charm.on.mongod_pebble_ready.emit(container)
-        password = self.harness.charm.app_peer_data["monitor_password"]
+        password = self.harness.charm.app_peer_data["monitor-password"]
 
         uri_template = "mongodb://monitor:{password}@mongodb-k8s-0.mongodb-k8s-endpoints/?replicaSet=mongodb-k8s&authSource=admin"
 
@@ -669,7 +669,7 @@ class TestCharm(unittest.TestCase):
         action_event = mock.Mock()
         action_event.params = {"username": "monitor", "password": "mongo123"}
         self.harness.charm._on_set_password(action_event)
-        password = self.harness.charm.app_peer_data["monitor_password"]
+        password = self.harness.charm.app_peer_data["monitor-password"]
 
         updated_plan = self.harness.get_container_pebble_plan("mongod").to_dict()
         new_uri = (


### PR DESCRIPTION
# About
The goal of the PR is to update user related secrets key names to be compatible with juju 3.1


# Related issues
DPE-2156