### PR TITLE
[DPE-2258] Secret performance fixed on juju31 edge

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -70,9 +70,13 @@ jobs:
           provider: microk8s
           channel: "1.27-strict/stable"
           # This is needed until https://bugs.launchpad.net/juju/+bug/1977582 is fixed
-          bootstrap-options: "--agent-version 3.1.5"
+          # bootstrap-options: "--agent-version 3.1.5"
           bootstrap-constraints: "cores=2 mem=2G"
-          juju-channel: "3.1/stable"
+          juju-channel: "3.1/edge"
+      - name: Setup 3.1.6 OCI image for test model units
+        run: |
+          docker pull jujusolutions/jujud-operator:3.1.6
+          docker save jujusolutions/jujud-operator:3.1.6 | sg snap_microk8s -c "microk8s.ctr --namespace k8s.io image import -"
       - name: Download packed charm(s)
         uses: actions/download-artifact@v3
         with:
@@ -93,6 +97,8 @@ jobs:
         run: sg snap_microk8s -c "tox run -e ${{ matrix.tox-environments }} -- --model testing -m '${{ steps.select-tests.outputs.mark_expression }}'"
         env:
           CI_PACKED_CHARMS: ${{ needs.build.outputs.charms }}
+      - name: Print debug logs
+        run: juju switch testing; juju debug-log --replay --no-tail --level=INFO | grep "SECRET"
       - name: Dump logs
         uses: canonical/charm-logdump-action@main
         if: failure()

--- a/src/charm.py
+++ b/src/charm.py
@@ -763,7 +763,10 @@ class MongoDBCharm(CharmBase):
             else:
                 secret_cache[key] = value
                 try:
+                    start = time.time()
                     secret.set_content(secret_cache)
+                    end = time.time()
+                    logging.info(f"[SECRET] Changing secret took {end - start}")
                 except OSError as error:
                     logging.error(
                         f"Error in attempt to set {scope}:{key}. "
@@ -775,7 +778,10 @@ class MongoDBCharm(CharmBase):
         else:
             scope_obj = self._scope_opj(scope)
 
+            start = time.time()
             secret = scope_obj.add_secret({key: value})
+            end = time.time()
+            logging.info(f"[SECRET] Adding secret took {end - start}")
             if not secret:
                 raise SecretNotAddedError(f"Couldn't set secret {scope}:{key}")
 
@@ -817,7 +823,10 @@ class MongoDBCharm(CharmBase):
             return
 
         secret_cache[key] = Config.Secrets.SECRET_DELETED_LABEL
+        start = time.time()
         secret.set_content(secret_cache)
+        end = time.time()
+        logging.info(f"[SECRET] Setting secret content took {end - start}")
         logging.debug(f"Secret {scope}:{key}")
 
     def remove_secret(self, scope, key) -> None:


### PR DESCRIPTION
This code is adding time measurements on Juju 3.1 secret operations. Specifically the ones introduced in https://github.com/canonical/mongodb-k8s-operator/pull/162 (https://github.com/canonical/mongodb-k8s-operator/pull/161)

Local tests confirm a performance issue fix accessing secrets.
```
unit-mongodb-k8s-0: 02:36:55 INFO unit.mongodb-k8s/0.juju-log database-peers:0: Adding secret took 0.003699064254760742
unit-mongodb-k8s-0: 02:36:55 INFO unit.mongodb-k8s/0.juju-log database-peers:0: Getting secret took 0.007857322692871094
unit-mongodb-k8s-0: 02:36:55 INFO unit.mongodb-k8s/0.juju-log database-peers:0: Chaning secret took 0.003070354461669922
unit-mongodb-k8s-0: 02:36:55 INFO unit.mongodb-k8s/0.juju-log database-peers:0: Chaning secret took 0.0031480789184570312
```

(NOTE:  HA scaling tests are disabled as there's ongoing work to find a fix for those on the base PR)