### PR TITLE
[DPE-2412]  Full cluster crash test

### DIFF
--- a/tests/integration/ha_tests/application_charm/src/continuous_writes.py
+++ b/tests/integration/ha_tests/application_charm/src/continuous_writes.py
@@ -6,7 +6,7 @@ import signal
 import sys
 
 from pymongo import MongoClient
-from pymongo.errors import AutoReconnect, NotPrimaryError, PyMongoError
+from pymongo.errors import AutoReconnect, NotPrimaryError, PyMongoError, OperationFailure
 from pymongo.write_concern import WriteConcern
 
 run = True
@@ -43,7 +43,15 @@ def continous_writes(connection_string: str, starting_number: int):
             # reconnect and re-write the previous value. Hence, we `continue` here, without
             # incrementing `write_value` as to try to insert this value again.
             continue
-        except PyMongoError:
+        except OperationFailure as e:
+            if e.code == 211:  # HMAC error
+                # after cluster comes back up, it needs to resync the HMAC code. Hence, we
+                # `continue` here, without incrementing `write_value` as to try to insert
+                # this value again.
+                continue
+            else:
+                pass
+        except PyMongoError as e:
             # we should not raise this exception but instead increment the write value and move
             # on, indicating that there was a failure writing to the database.
             pass

--- a/tests/integration/ha_tests/application_charm/src/continuous_writes.py
+++ b/tests/integration/ha_tests/application_charm/src/continuous_writes.py
@@ -6,7 +6,12 @@ import signal
 import sys
 
 from pymongo import MongoClient
-from pymongo.errors import AutoReconnect, NotPrimaryError, PyMongoError, OperationFailure
+from pymongo.errors import (
+    AutoReconnect,
+    NotPrimaryError,
+    OperationFailure,
+    PyMongoError,
+)
 from pymongo.write_concern import WriteConcern
 
 run = True
@@ -51,7 +56,7 @@ def continous_writes(connection_string: str, starting_number: int):
                 continue
             else:
                 pass
-        except PyMongoError as e:
+        except PyMongoError:
             # we should not raise this exception but instead increment the write value and move
             # on, indicating that there was a failure writing to the database.
             pass

--- a/tests/integration/ha_tests/helpers.py
+++ b/tests/integration/ha_tests/helpers.py
@@ -7,6 +7,8 @@ import os
 import string
 import subprocess
 import tempfile
+import tarfile
+import kubernetes as kubernetes
 from asyncio import gather
 from datetime import datetime
 from pathlib import Path
@@ -730,3 +732,178 @@ async def update_pebble_plans(ops_test: OpsTest, override: Dict[str, str]) -> No
         )
         ret_code, _, _ = await ops_test.juju(*replan_cmd)
         assert ret_code == 0, f"Failed to replan for unit {unit.name}"
+
+
+async def are_all_db_processes_down(ops_test: OpsTest, process: str) -> bool:
+    """Verifies that all units of the charm do not have the DB process running."""
+    app = await get_application_name(ops_test, APP_NAME)
+
+    if "/" in process:
+        pgrep_cmd = ("pgrep", "-f", process)
+    else:
+        pgrep_cmd = ("pgrep", "-x", process)
+
+    try:
+        for attempt in Retrying(stop=stop_after_delay(60), wait=wait_fixed(3)):
+            with attempt:
+                for unit in ops_test.model.applications[app].units:
+                    _, raw_pid, _ = await ops_test.juju(
+                        "ssh", "--container", MONGODB_CONTAINER_NAME, unit.name, *pgrep_cmd
+                    )
+
+                    # If something was returned, there is a running process.
+                    if len(raw_pid) > 0:
+                        raise ProcessRunningError
+    except RetryError:
+        return False
+
+    return True
+
+
+def modify_pebble_restart_delay(
+    ops_test: OpsTest,
+    unit_name: str,
+    pebble_plan_path: str,
+    ensure_replan: bool = False,
+) -> None:
+    """Modify the pebble restart delay of the underlying process.
+
+    Args:
+        ops_test: The ops test framework
+        unit_name: The name of unit to extend the pebble restart delay for
+        pebble_plan_path: Path to the file with the modified pebble plan
+        ensure_replan: Whether to check that the replan command succeeded
+    """
+    kubernetes.config.load_kube_config()
+    client = kubernetes.client.api.core_v1_api.CoreV1Api()
+
+    pod_name = unit_name.replace("/", "-")
+    container_name = "mongod"
+    service_name = "mongod"
+    now = datetime.now().isoformat()
+
+    print("\n\n\n\n\n\n")
+    print(
+        client,
+        ops_test.model.info.name,
+        pod_name,
+        container_name,
+        f"/tmp/pebble_plan_{now}.yml",
+        pebble_plan_path,
+    )
+    print("\n\n\n\n\n\n")
+    copy_file_into_pod(
+        client,
+        ops_test.model.info.name,
+        pod_name,
+        container_name,
+        f"/tmp/pebble_plan_{now}.yml",
+        pebble_plan_path,
+    )
+
+    add_to_pebble_layer_commands = (
+        f"/charm/bin/pebble add --combine {service_name} /tmp/pebble_plan_{now}.yml"
+    )
+    response = kubernetes.stream.stream(
+        client.connect_get_namespaced_pod_exec,
+        pod_name,
+        ops_test.model.info.name,
+        container=container_name,
+        command=add_to_pebble_layer_commands.split(),
+        stdin=False,
+        stdout=True,
+        stderr=True,
+        tty=False,
+        _preload_content=False,
+    )
+    response.run_forever(timeout=5)
+    assert (
+        response.returncode == 0
+    ), f"Failed to add to pebble layer, unit={unit_name}, container={container_name}, service={service_name}"
+
+    for attempt in Retrying(stop=stop_after_delay(60), wait=wait_fixed(3)):
+        with attempt:
+            replan_pebble_layer_commands = "/charm/bin/pebble replan"
+            response = kubernetes.stream.stream(
+                client.connect_get_namespaced_pod_exec,
+                pod_name,
+                ops_test.model.info.name,
+                container=container_name,
+                command=replan_pebble_layer_commands.split(),
+                stdin=False,
+                stdout=True,
+                stderr=True,
+                tty=False,
+                _preload_content=False,
+            )
+            response.run_forever(timeout=60)
+            if ensure_replan:
+                assert (
+                    response.returncode == 0
+                ), f"Failed to replan pebble layer, unit={unit_name}, container={container_name}, service={service_name}"
+
+
+def copy_file_into_pod(
+    client: kubernetes.client.api.core_v1_api.CoreV1Api,
+    namespace: str,
+    pod_name: str,
+    container_name: str,
+    destination_path: str,
+    source_path: str,
+) -> None:
+    """Copy file contents into pod.
+
+    Args:
+        client: The kubernetes CoreV1Api client
+        namespace: The namespace of the pod to copy files to
+        pod_name: The name of the pod to copy files to
+        container_name: The name of the pod container to copy files to
+        destination_path: The path to which the file should be copied over
+        source_path: The path of the file which needs to be copied over
+    """
+    try:
+        exec_command = ["tar", "xvf", "-", "-C", "/"]
+
+        print("\n\n\n\n\n\n\n\n\n\n\n")
+        print(
+            client.connect_get_namespaced_pod_exec,
+            pod_name,
+            namespace,
+            container_name,
+            exec_command,
+        )
+        print("\n\n\n\n\n\n\n\n\n\n\n")
+
+        api_response = kubernetes.stream.stream(
+            client.connect_get_namespaced_pod_exec,
+            pod_name,
+            namespace,
+            container=container_name,
+            command=exec_command,
+            stdin=True,
+            stdout=True,
+            stderr=True,
+            tty=False,
+            _preload_content=False,
+        )
+
+        with tempfile.TemporaryFile() as tar_buffer:
+            with tarfile.open(fileobj=tar_buffer, mode="w") as tar:
+                tar.add(source_path, destination_path)
+
+            tar_buffer.seek(0)
+            commands = []
+            commands.append(tar_buffer.read())
+
+            while api_response.is_open():
+                api_response.update(timeout=1)
+
+                if commands:
+                    command = commands.pop(0)
+                    api_response.write_stdin(command.decode())
+                else:
+                    break
+
+            api_response.close()
+    except kubernetes.client.rest.ApiException:
+        assert False

--- a/tests/integration/ha_tests/helpers.py
+++ b/tests/integration/ha_tests/helpers.py
@@ -782,16 +782,6 @@ def modify_pebble_restart_delay(
     service_name = "mongod"
     now = datetime.now().isoformat()
 
-    print("\n\n\n\n\n\n")
-    print(
-        client,
-        ops_test.model.info.name,
-        pod_name,
-        container_name,
-        f"/tmp/pebble_plan_{now}.yml",
-        pebble_plan_path,
-    )
-    print("\n\n\n\n\n\n")
     copy_file_into_pod(
         client,
         ops_test.model.info.name,
@@ -863,16 +853,6 @@ def copy_file_into_pod(
     """
     try:
         exec_command = ["tar", "xvf", "-", "-C", "/"]
-
-        print("\n\n\n\n\n\n\n\n\n\n\n")
-        print(
-            client.connect_get_namespaced_pod_exec,
-            pod_name,
-            namespace,
-            container_name,
-            exec_command,
-        )
-        print("\n\n\n\n\n\n\n\n\n\n\n")
 
         api_response = kubernetes.stream.stream(
             client.connect_get_namespaced_pod_exec,

--- a/tests/integration/ha_tests/helpers.py
+++ b/tests/integration/ha_tests/helpers.py
@@ -6,14 +6,14 @@ import logging
 import os
 import string
 import subprocess
-import tempfile
 import tarfile
-import kubernetes as kubernetes
+import tempfile
 from asyncio import gather
 from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Optional
 
+import kubernetes as kubernetes
 import ops
 import yaml
 from juju.unit import Unit

--- a/tests/integration/ha_tests/helpers.py
+++ b/tests/integration/ha_tests/helpers.py
@@ -735,7 +735,11 @@ async def update_pebble_plans(ops_test: OpsTest, override: Dict[str, str]) -> No
 
 
 async def are_all_db_processes_down(ops_test: OpsTest, process: str) -> bool:
-    """Verifies that all units of the charm do not have the DB process running."""
+    """Verifies that all units of the charm do not have the DB process running.
+
+    This checks that the `mongod` process is not running on each juju unit. Effectively, verifying
+    that the entire application hosting the cluster is down.
+    """
     app = await get_application_name(ops_test, APP_NAME)
 
     if "/" in process:

--- a/tests/integration/ha_tests/helpers.py
+++ b/tests/integration/ha_tests/helpers.py
@@ -840,8 +840,8 @@ def copy_file_into_pod(
     namespace: str,
     pod_name: str,
     container_name: str,
-    destination_path: str,
     source_path: str,
+    destination_path: str,
 ) -> None:
     """Copy file contents into pod.
 
@@ -850,8 +850,8 @@ def copy_file_into_pod(
         namespace: The namespace of the pod to copy files to
         pod_name: The name of the pod to copy files to
         container_name: The name of the pod container to copy files to
-        destination_path: The path to which the file should be copied over
-        source_path: The path of the file which needs to be copied over
+        source_path: The path to which the file should be copied over
+        destination_path: The path of the file which needs to be copied over
     """
     try:
         exec_command = ["tar", "xvf", "-", "-C", "/"]
@@ -871,7 +871,7 @@ def copy_file_into_pod(
 
         with tempfile.TemporaryFile() as tar_buffer:
             with tarfile.open(fileobj=tar_buffer, mode="w") as tar:
-                tar.add(source_path, destination_path)
+                tar.add(destination_path, source_path)
 
             tar_buffer.seek(0)
             commands = []

--- a/tests/integration/ha_tests/manifests/extend_pebble_restart_delay.yml
+++ b/tests/integration/ha_tests/manifests/extend_pebble_restart_delay.yml
@@ -1,5 +1,5 @@
 services:
   mongod:
     override: merge
-    backoff-delay: 150s
-    backoff-limit: 150s
+    backoff-delay: 180s
+    backoff-limit: 180s

--- a/tests/integration/ha_tests/manifests/extend_pebble_restart_delay.yml
+++ b/tests/integration/ha_tests/manifests/extend_pebble_restart_delay.yml
@@ -1,0 +1,5 @@
+services:
+  mongod:
+    override: merge
+    backoff-delay: 150s
+    backoff-limit: 150s

--- a/tests/integration/ha_tests/manifests/restore_pebble_restart_delay.yml
+++ b/tests/integration/ha_tests/manifests/restore_pebble_restart_delay.yml
@@ -1,0 +1,5 @@
+services:
+  mongod:
+    override: merge
+    backoff-delay: 500ms
+    backoff-limit: 30s

--- a/tests/integration/ha_tests/test_ha.py
+++ b/tests/integration/ha_tests/test_ha.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
+import asyncio
 import logging
 import time
 from datetime import datetime, timezone
@@ -8,7 +9,6 @@ from datetime import datetime, timezone
 import pytest
 import pytest_asyncio
 from pytest_operator.plugin import OpsTest
-import asyncio
 
 from ..helpers import APP_NAME
 from .helpers import (
@@ -58,7 +58,7 @@ MEDIAN_REELECTION_TIME = 12
 
 @pytest_asyncio.fixture
 async def continuous_writes(ops_test: OpsTest) -> None:
-    """Starts continuous writes to the MongoDB cluster for a test and clear the writes at the end."""
+    """Starts continuous writes to the MongoDB cluster and clear the writes at the end."""
     application_name = await get_application_name(ops_test, "application")
 
     application_unit = ops_test.model.applications[application_name].units[0]
@@ -120,280 +120,280 @@ async def test_build_and_deploy(ops_test: OpsTest, cmd_mongodb_charm) -> None:
     await relate_mongodb_and_application(ops_test, mongodb_application_name, application_name)
 
 
-# @pytest.mark.abort_on_fail
-# async def test_scale_up_capablities(ops_test: OpsTest, continuous_writes) -> None:
-#     """Tests juju add-unit functionality.
+@pytest.mark.abort_on_fail
+async def test_scale_up_capablities(ops_test: OpsTest, continuous_writes) -> None:
+    """Tests juju add-unit functionality.
 
-#     Verifies that when a new unit is added to the MongoDB application that it is added to the
-#     MongoDB replica set configuration.
-#     """
-#     # add units and wait for idle
-#     app = await get_application_name(ops_test, APP_NAME)
-#     await scale_application(ops_test, app, len(ops_test.model.applications[app].units) + 2)
+    Verifies that when a new unit is added to the MongoDB application that it is added to the
+    MongoDB replica set configuration.
+    """
+    # add units and wait for idle
+    app = await get_application_name(ops_test, APP_NAME)
+    await scale_application(ops_test, app, len(ops_test.model.applications[app].units) + 2)
 
-#     # grab unit hosts
-#     hostnames = await get_units_hostnames(ops_test)
+    # grab unit hosts
+    hostnames = await get_units_hostnames(ops_test)
 
-#     # connect to replica set uri and get replica set members
-#     member_hosts = await fetch_replica_set_members(ops_test)
+    # connect to replica set uri and get replica set members
+    member_hosts = await fetch_replica_set_members(ops_test)
 
-#     # verify that the replica set members have the correct units
-#     assert set(member_hosts) == set(hostnames), "all members not running under the same replset"
+    # verify that the replica set members have the correct units
+    assert set(member_hosts) == set(hostnames), "all members not running under the same replset"
 
-#     # verify that the no writes were skipped
-#     await verify_writes(ops_test)
-
-
-# @pytest.mark.abort_on_fail
-# async def test_scale_down_capablities(ops_test: OpsTest, continuous_writes) -> None:
-#     """Tests clusters behavior when scaling down a minority and removing a primary replica."""
-#     app = await get_application_name(ops_test, APP_NAME)
-#     minority_count = int(len(ops_test.model.applications[app].units) // 2)
-#     expected_units = len(ops_test.model.applications[app].units) - minority_count
-
-#     # find leader unit
-#     leader_unit = await find_unit(ops_test, leader=True)
-
-#     # verify that we have a leader
-#     assert leader_unit is not None, "No unit is leader"
-
-#     # Force delete the leader and scale down
-#     await kubectl_delete(ops_test, leader_unit, False)
-#     await scale_application(ops_test, app, expected_units)
-
-#     # grab unit hosts
-#     hostnames = await get_units_hostnames(ops_test)
-
-#     # check that the replica set with the remaining units has a primary
-#     primary = await get_replica_set_primary(ops_test)
-
-#     # verify that the primary is not None
-#     assert primary is not None, "replica set has no primary"
-
-#     # check that the primary is one of the remaining units
-#     assert (
-#         f"{primary.name.replace('/', '-')}.mongodb-k8s-endpoints" in hostnames
-#     ), "replica set primary is not one of the available units"
-
-#     # verify that the configuration of mongodb no longer has the deleted ip
-#     member_hosts = await fetch_replica_set_members(ops_test)
-
-#     # verify that the replica set members have the correct units
-#     assert set(member_hosts) == set(hostnames), "mongod config contains deleted units"
-
-#     # verify that the no writes were skipped
-#     await verify_writes(ops_test)
+    # verify that the no writes were skipped
+    await verify_writes(ops_test)
 
 
-# async def test_replication_across_members(ops_test: OpsTest, continuous_writes) -> None:
-#     """Check consistency, ie write to primary, read data from secondaries."""
-#     # verify that the no writes were skipped
-#     await verify_writes(ops_test)
+@pytest.mark.abort_on_fail
+async def test_scale_down_capablities(ops_test: OpsTest, continuous_writes) -> None:
+    """Tests clusters behavior when scaling down a minority and removing a primary replica."""
+    app = await get_application_name(ops_test, APP_NAME)
+    minority_count = int(len(ops_test.model.applications[app].units) // 2)
+    expected_units = len(ops_test.model.applications[app].units) - minority_count
+
+    # find leader unit
+    leader_unit = await find_unit(ops_test, leader=True)
+
+    # verify that we have a leader
+    assert leader_unit is not None, "No unit is leader"
+
+    # Force delete the leader and scale down
+    await kubectl_delete(ops_test, leader_unit, False)
+    await scale_application(ops_test, app, expected_units)
+
+    # grab unit hosts
+    hostnames = await get_units_hostnames(ops_test)
+
+    # check that the replica set with the remaining units has a primary
+    primary = await get_replica_set_primary(ops_test)
+
+    # verify that the primary is not None
+    assert primary is not None, "replica set has no primary"
+
+    # check that the primary is one of the remaining units
+    assert (
+        f"{primary.name.replace('/', '-')}.mongodb-k8s-endpoints" in hostnames
+    ), "replica set primary is not one of the available units"
+
+    # verify that the configuration of mongodb no longer has the deleted ip
+    member_hosts = await fetch_replica_set_members(ops_test)
+
+    # verify that the replica set members have the correct units
+    assert set(member_hosts) == set(hostnames), "mongod config contains deleted units"
+
+    # verify that the no writes were skipped
+    await verify_writes(ops_test)
 
 
-# async def test_unique_cluster_dbs(ops_test: OpsTest, continuous_writes, cmd_mongodb_charm) -> None:
-#     """Verify unique clusters do not share DBs."""
-#     # first find primary, write to primary,
-#     await insert_record_in_collection(ops_test)
-
-#     # deploy new cluster
-#     if ANOTHER_DATABASE_APP_NAME not in ops_test.model.applications:
-#         await deploy_and_scale_mongodb(
-#             ops_test, False, ANOTHER_DATABASE_APP_NAME, 1, cmd_mongodb_charm
-#         )
-
-#     # write data to new cluster
-#     with await get_other_mongodb_direct_client(ops_test, ANOTHER_DATABASE_APP_NAME) as client:
-#         db = client["new-db"]
-#         test_collection = db["test_ubuntu_collection"]
-#         test_collection.insert_one({"release_name": "Jammy Jelly", "version": 22.04, "LTS": False})
-
-#         cluster_1_entries = retrieve_entries(
-#             client,
-#             db_name="new-db",
-#             collection_name="test_ubuntu_collection",
-#             query_field="release_name",
-#         )
-#     with await get_mongo_client(ops_test) as client:
-#         cluster_2_entries = retrieve_entries(
-#             client,
-#             db_name="new-db",
-#             collection_name="test_ubuntu_collection",
-#             query_field="release_name",
-#         )
-
-#     common_entries = cluster_2_entries.intersection(cluster_1_entries)
-#     assert len(common_entries) == 0, "Writes from one cluster are replicated to another cluster."
-
-#     # verify that the no writes were skipped
-#     await find_record_in_collection(ops_test)
-#     await verify_writes(ops_test)
+async def test_replication_across_members(ops_test: OpsTest, continuous_writes) -> None:
+    """Check consistency, ie write to primary, read data from secondaries."""
+    # verify that the no writes were skipped
+    await verify_writes(ops_test)
 
 
-# async def test_kill_db_process(ops_test: OpsTest, continuous_writes):
-#     # locate primary unit
-#     hostnames = await get_units_hostnames(ops_test)
-#     primary = await get_replica_set_primary(ops_test)
+async def test_unique_cluster_dbs(ops_test: OpsTest, continuous_writes, cmd_mongodb_charm) -> None:
+    """Verify unique clusters do not share DBs."""
+    # first find primary, write to primary,
+    await insert_record_in_collection(ops_test)
 
-#     mongodb_pid = await get_process_pid(
-#         ops_test, primary.name, MONGODB_CONTAINER_NAME, MONGOD_PROCESS_NAME
-#     )
+    # deploy new cluster
+    if ANOTHER_DATABASE_APP_NAME not in ops_test.model.applications:
+        await deploy_and_scale_mongodb(
+            ops_test, False, ANOTHER_DATABASE_APP_NAME, 1, cmd_mongodb_charm
+        )
 
-#     await send_signal_to_pod_container_process(
-#         ops_test,
-#         primary.name,
-#         MONGODB_CONTAINER_NAME,
-#         MONGOD_PROCESS_NAME,
-#         "SIGKILL",
-#     )
+    # write data to new cluster
+    with await get_other_mongodb_direct_client(ops_test, ANOTHER_DATABASE_APP_NAME) as client:
+        db = client["new-db"]
+        test_collection = db["test_ubuntu_collection"]
+        test_collection.insert_one({"release_name": "Jammy Jelly", "version": 22.04, "LTS": False})
 
-#     # sleep for twice the median election time
-#     time.sleep(MEDIAN_REELECTION_TIME * 2)
+        cluster_1_entries = retrieve_entries(
+            client,
+            db_name="new-db",
+            collection_name="test_ubuntu_collection",
+            query_field="release_name",
+        )
+    with await get_mongo_client(ops_test) as client:
+        cluster_2_entries = retrieve_entries(
+            client,
+            db_name="new-db",
+            collection_name="test_ubuntu_collection",
+            query_field="release_name",
+        )
 
-#     # verify new writes are continuing by counting the number of writes before and after a 5 second
-#     # wait
-#     with await get_mongo_client(ops_test, excluded=[primary.name]) as client:
-#         writes = client[TEST_DB][TEST_COLLECTION].count_documents({})
-#         time.sleep(5)
-#         more_writes = client[TEST_DB][TEST_COLLECTION].count_documents({})
-#     assert more_writes > writes, "writes not continuing to DB"
+    common_entries = cluster_2_entries.intersection(cluster_1_entries)
+    assert len(common_entries) == 0, "Writes from one cluster are replicated to another cluster."
 
-#     # verify that db service got restarted and is ready
-#     old_primary_unit = int(primary.name.split("/")[1])
-#     assert await mongod_ready(ops_test, old_primary_unit)
-#     new_mongodb_pid = await get_process_pid(
-#         ops_test, primary.name, MONGODB_CONTAINER_NAME, MONGOD_PROCESS_NAME
-#     )
-#     assert (
-#         mongodb_pid != new_mongodb_pid
-#     ), "The mongodb process id is the same after sending it a SIGKILL"
-
-#     # verify that a new primary gets elected (ie old primary is secondary)
-#     new_primary = await get_replica_set_primary(ops_test)
-#     assert (
-#         primary.name != new_primary.name
-#     ), "The mongodb primary has not been reelected after sending a SIGKILL"
-
-#     # verify all units are running under the same replset
-#     member_hosts = await fetch_replica_set_members(ops_test)
-#     assert set(member_hosts) == set(hostnames), "all members not running under the same replset"
-
-#     # verify there is only one primary after killing old primary
-#     assert (
-#         await count_primaries(ops_test) == 1
-#     ), "there are more than one primary in the replica set."
-
-#     # verify that no writes to the db were missed
-#     await verify_writes(ops_test)
+    # verify that the no writes were skipped
+    await find_record_in_collection(ops_test)
+    await verify_writes(ops_test)
 
 
-# async def test_freeze_db_process(ops_test, continuous_writes):
-#     # locate primary unit
-#     hostnames = await get_units_hostnames(ops_test)
-#     primary = await get_replica_set_primary(ops_test)
+async def test_kill_db_process(ops_test: OpsTest, continuous_writes):
+    # locate primary unit
+    hostnames = await get_units_hostnames(ops_test)
+    primary = await get_replica_set_primary(ops_test)
 
-#     await send_signal_to_pod_container_process(
-#         ops_test,
-#         primary.name,
-#         MONGODB_CONTAINER_NAME,
-#         MONGOD_PROCESS_NAME,
-#         "SIGSTOP",
-#     )
+    mongodb_pid = await get_process_pid(
+        ops_test, primary.name, MONGODB_CONTAINER_NAME, MONGOD_PROCESS_NAME
+    )
 
-#     # sleep for twice the median election time
-#     time.sleep(MEDIAN_REELECTION_TIME * 2)
+    await send_signal_to_pod_container_process(
+        ops_test,
+        primary.name,
+        MONGODB_CONTAINER_NAME,
+        MONGOD_PROCESS_NAME,
+        "SIGKILL",
+    )
 
-#     # verify that a new primary gets elected, old primary is still frozen
-#     new_primary = await get_replica_set_primary(ops_test, excluded=[primary.name])
-#     assert (
-#         primary.name != new_primary.name
-#     ), "The mongodb primary has not been reelected after sending a SIGSTOP"
+    # sleep for twice the median election time
+    time.sleep(MEDIAN_REELECTION_TIME * 2)
 
-#     # verify new writes are continuing by counting the number of writes before and after a 5 second
-#     # wait
-#     with await get_mongo_client(ops_test, excluded=[primary.name]) as client:
-#         writes = client[TEST_DB][TEST_COLLECTION].count_documents({})
-#         time.sleep(5)
-#         more_writes = client[TEST_DB][TEST_COLLECTION].count_documents({})
+    # verify new writes are continuing by counting the number of writes before and after a 5 second
+    # wait
+    with await get_mongo_client(ops_test, excluded=[primary.name]) as client:
+        writes = client[TEST_DB][TEST_COLLECTION].count_documents({})
+        time.sleep(5)
+        more_writes = client[TEST_DB][TEST_COLLECTION].count_documents({})
+    assert more_writes > writes, "writes not continuing to DB"
 
-#     # un-freeze the old primary
-#     await send_signal_to_pod_container_process(
-#         ops_test,
-#         primary.name,
-#         MONGODB_CONTAINER_NAME,
-#         MONGOD_PROCESS_NAME,
-#         "SIGCONT",
-#     )
+    # verify that db service got restarted and is ready
+    old_primary_unit = int(primary.name.split("/")[1])
+    assert await mongod_ready(ops_test, old_primary_unit)
+    new_mongodb_pid = await get_process_pid(
+        ops_test, primary.name, MONGODB_CONTAINER_NAME, MONGOD_PROCESS_NAME
+    )
+    assert (
+        mongodb_pid != new_mongodb_pid
+    ), "The mongodb process id is the same after sending it a SIGKILL"
 
-#     # check this after un-freezing the old primary so that if this check fails we still "turned
-#     # back on" the mongod process
-#     assert more_writes > writes, "writes not continuing to DB"
+    # verify that a new primary gets elected (ie old primary is secondary)
+    new_primary = await get_replica_set_primary(ops_test)
+    assert (
+        primary.name != new_primary.name
+    ), "The mongodb primary has not been reelected after sending a SIGKILL"
 
-#     # verify that db service got restarted and is ready
-#     old_primary_unit = int(primary.name.split("/")[1])
-#     assert await mongod_ready(ops_test, old_primary_unit)
+    # verify all units are running under the same replset
+    member_hosts = await fetch_replica_set_members(ops_test)
+    assert set(member_hosts) == set(hostnames), "all members not running under the same replset"
 
-#     # verify all units are running under the same replset
-#     member_hosts = await fetch_replica_set_members(ops_test)
-#     assert set(member_hosts) == set(hostnames), "all members not running under the same replset"
+    # verify there is only one primary after killing old primary
+    assert (
+        await count_primaries(ops_test) == 1
+    ), "there are more than one primary in the replica set."
 
-#     # verify there is only one primary after un-freezing old primary
-#     assert (
-#         await count_primaries(ops_test) == 1
-#     ), "there are more than one primary in the replica set."
-
-#     # verify that the old primary does not "reclaim" primary status after un-freezing old primary
-#     new_primary = await get_replica_set_primary(ops_test)
-#     assert new_primary.name != primary.name, "un-frozen primary should be secondary."
-
-#     # verify that no writes were missed.
-#     await verify_writes(ops_test)
+    # verify that no writes to the db were missed
+    await verify_writes(ops_test)
 
 
-# async def test_restart_db_process(ops_test, continuous_writes, change_logging):
-#     # locate primary unit
-#     old_primary = await get_replica_set_primary(ops_test)
+async def test_freeze_db_process(ops_test, continuous_writes):
+    # locate primary unit
+    hostnames = await get_units_hostnames(ops_test)
+    primary = await get_replica_set_primary(ops_test)
 
-#     # send SIGTERM
-#     sig_term_time = datetime.now(timezone.utc)
-#     await send_signal_to_pod_container_process(
-#         ops_test,
-#         old_primary.name,
-#         MONGODB_CONTAINER_NAME,
-#         MONGOD_PROCESS_NAME,
-#         "SIGTERM",
-#     )
-#     # verify that a stepdown was performed on restart. SIGTERM should send a graceful restart and
-#     # send a replica step down signal. Pipes k8s logs output to see if any of the pods received a
-#     # stepdown request. Must be done early otherwise continuous writes may flood the logs
-#     await check_db_stepped_down(ops_test, sig_term_time)
+    await send_signal_to_pod_container_process(
+        ops_test,
+        primary.name,
+        MONGODB_CONTAINER_NAME,
+        MONGOD_PROCESS_NAME,
+        "SIGSTOP",
+    )
 
-#     # sleep for twice the median election time
-#     time.sleep(MEDIAN_REELECTION_TIME * 2)
+    # sleep for twice the median election time
+    time.sleep(MEDIAN_REELECTION_TIME * 2)
 
-#     # verify new writes are continuing by counting the number of writes before and after a 5 second
-#     # wait
-#     with await get_mongo_client(ops_test, excluded=[old_primary.name]) as client:
-#         writes = client[TEST_DB][TEST_COLLECTION].count_documents({})
-#         time.sleep(5)
-#         more_writes = client[TEST_DB][TEST_COLLECTION].count_documents({})
-#     assert more_writes > writes, "writes not continuing to DB"
+    # verify that a new primary gets elected, old primary is still frozen
+    new_primary = await get_replica_set_primary(ops_test, excluded=[primary.name])
+    assert (
+        primary.name != new_primary.name
+    ), "The mongodb primary has not been reelected after sending a SIGSTOP"
 
-#     # verify that db service got restarted and is ready
-#     old_primary_unit = int(old_primary.name.split("/")[1])
-#     assert await mongod_ready(ops_test, old_primary_unit)
+    # verify new writes are continuing by counting the number of writes before and after a 5 second
+    # wait
+    with await get_mongo_client(ops_test, excluded=[primary.name]) as client:
+        writes = client[TEST_DB][TEST_COLLECTION].count_documents({})
+        time.sleep(5)
+        more_writes = client[TEST_DB][TEST_COLLECTION].count_documents({})
 
-#     # verify that a new primary gets elected (ie old primary is secondary)
-#     new_primary = await get_replica_set_primary(ops_test)
-#     assert new_primary.name != old_primary.name
+    # un-freeze the old primary
+    await send_signal_to_pod_container_process(
+        ops_test,
+        primary.name,
+        MONGODB_CONTAINER_NAME,
+        MONGOD_PROCESS_NAME,
+        "SIGCONT",
+    )
 
-#     # verify there is only one primary after killing old primary
-#     assert (
-#         await count_primaries(ops_test) == 1
-#     ), "there are more than one primary in the replica set."
+    # check this after un-freezing the old primary so that if this check fails we still "turned
+    # back on" the mongod process
+    assert more_writes > writes, "writes not continuing to DB"
 
-#     # verify that old primary is up to date.
-#     await verify_writes(ops_test)
+    # verify that db service got restarted and is ready
+    old_primary_unit = int(primary.name.split("/")[1])
+    assert await mongod_ready(ops_test, old_primary_unit)
+
+    # verify all units are running under the same replset
+    member_hosts = await fetch_replica_set_members(ops_test)
+    assert set(member_hosts) == set(hostnames), "all members not running under the same replset"
+
+    # verify there is only one primary after un-freezing old primary
+    assert (
+        await count_primaries(ops_test) == 1
+    ), "there are more than one primary in the replica set."
+
+    # verify that the old primary does not "reclaim" primary status after un-freezing old primary
+    new_primary = await get_replica_set_primary(ops_test)
+    assert new_primary.name != primary.name, "un-frozen primary should be secondary."
+
+    # verify that no writes were missed.
+    await verify_writes(ops_test)
+
+
+async def test_restart_db_process(ops_test, continuous_writes, change_logging):
+    # locate primary unit
+    old_primary = await get_replica_set_primary(ops_test)
+
+    # send SIGTERM
+    sig_term_time = datetime.now(timezone.utc)
+    await send_signal_to_pod_container_process(
+        ops_test,
+        old_primary.name,
+        MONGODB_CONTAINER_NAME,
+        MONGOD_PROCESS_NAME,
+        "SIGTERM",
+    )
+    # verify that a stepdown was performed on restart. SIGTERM should send a graceful restart and
+    # send a replica step down signal. Pipes k8s logs output to see if any of the pods received a
+    # stepdown request. Must be done early otherwise continuous writes may flood the logs
+    await check_db_stepped_down(ops_test, sig_term_time)
+
+    # sleep for twice the median election time
+    time.sleep(MEDIAN_REELECTION_TIME * 2)
+
+    # verify new writes are continuing by counting the number of writes before and after a 5 second
+    # wait
+    with await get_mongo_client(ops_test, excluded=[old_primary.name]) as client:
+        writes = client[TEST_DB][TEST_COLLECTION].count_documents({})
+        time.sleep(5)
+        more_writes = client[TEST_DB][TEST_COLLECTION].count_documents({})
+    assert more_writes > writes, "writes not continuing to DB"
+
+    # verify that db service got restarted and is ready
+    old_primary_unit = int(old_primary.name.split("/")[1])
+    assert await mongod_ready(ops_test, old_primary_unit)
+
+    # verify that a new primary gets elected (ie old primary is secondary)
+    new_primary = await get_replica_set_primary(ops_test)
+    assert new_primary.name != old_primary.name
+
+    # verify there is only one primary after killing old primary
+    assert (
+        await count_primaries(ops_test) == 1
+    ), "there are more than one primary in the replica set."
+
+    # verify that old primary is up to date.
+    await verify_writes(ops_test)
 
 
 async def test_full_cluster_crash(ops_test: OpsTest, continuous_writes):
@@ -468,53 +468,53 @@ async def test_full_cluster_crash(ops_test: OpsTest, continuous_writes):
     await verify_writes(ops_test)
 
 
-# async def test_network_cut(ops_test: OpsTest, continuous_writes, chaos_mesh):
-#     app = await get_application_name(ops_test, APP_NAME)
+async def test_network_cut(ops_test: OpsTest, continuous_writes, chaos_mesh):
+    app = await get_application_name(ops_test, APP_NAME)
 
-#     # retrieve a primary unit and a non-primary unit (active-unit). The primary unit will have its
-#     # network disrupted, while the active unit allows us to communicate to `mongod`
-#     primary = await get_replica_set_primary(ops_test)
-#     active_unit = [
-#         unit for unit in ops_test.model.applications[app].units if unit.name != primary.name
-#     ][0]
+    # retrieve a primary unit and a non-primary unit (active-unit). The primary unit will have its
+    # network disrupted, while the active unit allows us to communicate to `mongod`
+    primary = await get_replica_set_primary(ops_test)
+    active_unit = [
+        unit for unit in ops_test.model.applications[app].units if unit.name != primary.name
+    ][0]
 
-#     # grab unit hosts
-#     hostnames = await get_units_hostnames(ops_test)
+    # grab unit hosts
+    hostnames = await get_units_hostnames(ops_test)
 
-#     # Create networkchaos policy to isolate instance from cluster
-#     isolate_instance_from_cluster(ops_test, primary.name)
-#     logger.info(f"Primary instance {primary.name} isolated from cluster")
-#     # sleep for twice the median election time
-#     time.sleep(MEDIAN_REELECTION_TIME * 2)
+    # Create networkchaos policy to isolate instance from cluster
+    isolate_instance_from_cluster(ops_test, primary.name)
+    logger.info(f"Primary instance {primary.name} isolated from cluster")
+    # sleep for twice the median election time
+    time.sleep(MEDIAN_REELECTION_TIME * 2)
 
-#     # Wait until Mongodb actually detects isolated instance
-#     logger.info(f"Waiting until Mongodb detects primary instance {primary.name} is not reachable")
-#     await wait_until_unit_in_status(ops_test, primary, active_unit, "(not reachable/healthy)")
+    # Wait until Mongodb actually detects isolated instance
+    logger.info(f"Waiting until Mongodb detects primary instance {primary.name} is not reachable")
+    await wait_until_unit_in_status(ops_test, primary, active_unit, "(not reachable/healthy)")
 
-#     # verify new writes are continuing by counting the number of writes before and after a 5 second
-#     # wait
-#     logger.info("Validating writes are continuing to DB")
-#     with await get_mongo_client(ops_test, excluded=[primary.name]) as client:
-#         writes = client[TEST_DB][TEST_COLLECTION].count_documents({})
-#         time.sleep(5)
-#         more_writes = client[TEST_DB][TEST_COLLECTION].count_documents({})
-#     assert more_writes > writes, "writes not continuing to DB"
+    # verify new writes are continuing by counting the number of writes before and after a 5 second
+    # wait
+    logger.info("Validating writes are continuing to DB")
+    with await get_mongo_client(ops_test, excluded=[primary.name]) as client:
+        writes = client[TEST_DB][TEST_COLLECTION].count_documents({})
+        time.sleep(5)
+        more_writes = client[TEST_DB][TEST_COLLECTION].count_documents({})
+    assert more_writes > writes, "writes not continuing to DB"
 
-#     # verify that a new primary got elected, old primary is still cut off
-#     new_primary = await get_replica_set_primary(ops_test, excluded=[primary.name])
-#     assert new_primary.name != primary.name
+    # verify that a new primary got elected, old primary is still cut off
+    new_primary = await get_replica_set_primary(ops_test, excluded=[primary.name])
+    assert new_primary.name != primary.name
 
-#     # Remove networkchaos policy isolating instance from cluster
-#     remove_instance_isolation(ops_test)
+    # Remove networkchaos policy isolating instance from cluster
+    remove_instance_isolation(ops_test)
 
-#     await wait_until_unit_in_status(ops_test, primary, active_unit, "SECONDARY")
+    await wait_until_unit_in_status(ops_test, primary, active_unit, "SECONDARY")
 
-#     # verify presence of primary, replica set member configuration, and number of primaries
-#     member_hosts = await fetch_replica_set_members(ops_test)
-#     assert set(member_hosts) == set(hostnames)
-#     assert (
-#         await count_primaries(ops_test) == 1
-#     ), "there is more than one primary in the replica set."
+    # verify presence of primary, replica set member configuration, and number of primaries
+    member_hosts = await fetch_replica_set_members(ops_test)
+    assert set(member_hosts) == set(hostnames)
+    assert (
+        await count_primaries(ops_test) == 1
+    ), "there is more than one primary in the replica set."
 
-#     # verify that old primary is up to date.
-#     await verify_writes(ops_test)
+    # verify that old primary is up to date.
+    await verify_writes(ops_test)

--- a/tests/integration/ha_tests/test_ha.py
+++ b/tests/integration/ha_tests/test_ha.py
@@ -442,7 +442,7 @@ async def test_full_cluster_crash(ops_test: OpsTest, continuous_writes):
 
     # verify all units are up and running
     for unit in ops_test.model.applications[mongodb_application_name].units:
-        assert await mongod_ready(ops_test, unit)
+        assert await mongod_ready(ops_test, int(unit.name.split("/")[1]))
 
     # verify new writes are continuing by counting the number of writes before and after a 5 second
     # wait

--- a/tests/integration/ha_tests/test_ha.py
+++ b/tests/integration/ha_tests/test_ha.py
@@ -427,8 +427,6 @@ async def test_full_cluster_crash(ops_test: OpsTest, continuous_writes):
             ops_test, MONGOD_PROCESS_NAME
         ), "Not all units down at the same time."
     finally:
-        # TODO this sets them to a spec restart delay, it would be better to determine the
-        # original delay and revert pebble to that
         for unit in ops_test.model.applications[mongodb_application_name].units:
             modify_pebble_restart_delay(
                 ops_test,

--- a/tests/integration/ha_tests/test_ha.py
+++ b/tests/integration/ha_tests/test_ha.py
@@ -8,6 +8,7 @@ from datetime import datetime, timezone
 import pytest
 import pytest_asyncio
 from pytest_operator.plugin import OpsTest
+import asyncio
 
 from ..helpers import APP_NAME
 from .helpers import (
@@ -16,6 +17,7 @@ from .helpers import (
     MONGODB_CONTAINER_NAME,
     TEST_COLLECTION,
     TEST_DB,
+    are_all_db_processes_down,
     check_db_stepped_down,
     count_primaries,
     deploy_and_scale_application,
@@ -34,6 +36,7 @@ from .helpers import (
     insert_record_in_collection,
     isolate_instance_from_cluster,
     kubectl_delete,
+    modify_pebble_restart_delay,
     mongod_ready,
     relate_mongodb_and_application,
     remove_instance_isolation,
@@ -49,12 +52,13 @@ from .helpers import (
 
 logger = logging.getLogger(__name__)
 
+RESTART_DELAY = 60 * 3
 MEDIAN_REELECTION_TIME = 12
 
 
 @pytest_asyncio.fixture
 async def continuous_writes(ops_test: OpsTest) -> None:
-    """Starts continuous writes to the MySQL cluster for a test and clear the writes at the end."""
+    """Starts continuous writes to the MongoDB cluster for a test and clear the writes at the end."""
     application_name = await get_application_name(ops_test, "application")
 
     application_unit = ops_test.model.applications[application_name].units[0]
@@ -116,220 +120,342 @@ async def test_build_and_deploy(ops_test: OpsTest, cmd_mongodb_charm) -> None:
     await relate_mongodb_and_application(ops_test, mongodb_application_name, application_name)
 
 
-@pytest.mark.abort_on_fail
-async def test_scale_up_capablities(ops_test: OpsTest, continuous_writes) -> None:
-    """Tests juju add-unit functionality.
+# @pytest.mark.abort_on_fail
+# async def test_scale_up_capablities(ops_test: OpsTest, continuous_writes) -> None:
+#     """Tests juju add-unit functionality.
 
-    Verifies that when a new unit is added to the MongoDB application that it is added to the
-    MongoDB replica set configuration.
-    """
-    # add units and wait for idle
-    app = await get_application_name(ops_test, APP_NAME)
-    await scale_application(ops_test, app, len(ops_test.model.applications[app].units) + 2)
+#     Verifies that when a new unit is added to the MongoDB application that it is added to the
+#     MongoDB replica set configuration.
+#     """
+#     # add units and wait for idle
+#     app = await get_application_name(ops_test, APP_NAME)
+#     await scale_application(ops_test, app, len(ops_test.model.applications[app].units) + 2)
 
-    # grab unit hosts
-    hostnames = await get_units_hostnames(ops_test)
+#     # grab unit hosts
+#     hostnames = await get_units_hostnames(ops_test)
 
-    # connect to replica set uri and get replica set members
-    member_hosts = await fetch_replica_set_members(ops_test)
+#     # connect to replica set uri and get replica set members
+#     member_hosts = await fetch_replica_set_members(ops_test)
 
-    # verify that the replica set members have the correct units
-    assert set(member_hosts) == set(hostnames), "all members not running under the same replset"
+#     # verify that the replica set members have the correct units
+#     assert set(member_hosts) == set(hostnames), "all members not running under the same replset"
 
-    # verify that the no writes were skipped
-    await verify_writes(ops_test)
-
-
-@pytest.mark.abort_on_fail
-async def test_scale_down_capablities(ops_test: OpsTest, continuous_writes) -> None:
-    """Tests clusters behavior when scaling down a minority and removing a primary replica."""
-    app = await get_application_name(ops_test, APP_NAME)
-    minority_count = int(len(ops_test.model.applications[app].units) // 2)
-    expected_units = len(ops_test.model.applications[app].units) - minority_count
-
-    # find leader unit
-    leader_unit = await find_unit(ops_test, leader=True)
-
-    # verify that we have a leader
-    assert leader_unit is not None, "No unit is leader"
-
-    # Force delete the leader and scale down
-    await kubectl_delete(ops_test, leader_unit, False)
-    await scale_application(ops_test, app, expected_units)
-
-    # grab unit hosts
-    hostnames = await get_units_hostnames(ops_test)
-
-    # check that the replica set with the remaining units has a primary
-    primary = await get_replica_set_primary(ops_test)
-
-    # verify that the primary is not None
-    assert primary is not None, "replica set has no primary"
-
-    # check that the primary is one of the remaining units
-    assert (
-        f"{primary.name.replace('/', '-')}.mongodb-k8s-endpoints" in hostnames
-    ), "replica set primary is not one of the available units"
-
-    # verify that the configuration of mongodb no longer has the deleted ip
-    member_hosts = await fetch_replica_set_members(ops_test)
-
-    # verify that the replica set members have the correct units
-    assert set(member_hosts) == set(hostnames), "mongod config contains deleted units"
-
-    # verify that the no writes were skipped
-    await verify_writes(ops_test)
+#     # verify that the no writes were skipped
+#     await verify_writes(ops_test)
 
 
-async def test_replication_across_members(ops_test: OpsTest, continuous_writes) -> None:
-    """Check consistency, ie write to primary, read data from secondaries."""
-    # verify that the no writes were skipped
-    await verify_writes(ops_test)
+# @pytest.mark.abort_on_fail
+# async def test_scale_down_capablities(ops_test: OpsTest, continuous_writes) -> None:
+#     """Tests clusters behavior when scaling down a minority and removing a primary replica."""
+#     app = await get_application_name(ops_test, APP_NAME)
+#     minority_count = int(len(ops_test.model.applications[app].units) // 2)
+#     expected_units = len(ops_test.model.applications[app].units) - minority_count
+
+#     # find leader unit
+#     leader_unit = await find_unit(ops_test, leader=True)
+
+#     # verify that we have a leader
+#     assert leader_unit is not None, "No unit is leader"
+
+#     # Force delete the leader and scale down
+#     await kubectl_delete(ops_test, leader_unit, False)
+#     await scale_application(ops_test, app, expected_units)
+
+#     # grab unit hosts
+#     hostnames = await get_units_hostnames(ops_test)
+
+#     # check that the replica set with the remaining units has a primary
+#     primary = await get_replica_set_primary(ops_test)
+
+#     # verify that the primary is not None
+#     assert primary is not None, "replica set has no primary"
+
+#     # check that the primary is one of the remaining units
+#     assert (
+#         f"{primary.name.replace('/', '-')}.mongodb-k8s-endpoints" in hostnames
+#     ), "replica set primary is not one of the available units"
+
+#     # verify that the configuration of mongodb no longer has the deleted ip
+#     member_hosts = await fetch_replica_set_members(ops_test)
+
+#     # verify that the replica set members have the correct units
+#     assert set(member_hosts) == set(hostnames), "mongod config contains deleted units"
+
+#     # verify that the no writes were skipped
+#     await verify_writes(ops_test)
 
 
-async def test_unique_cluster_dbs(ops_test: OpsTest, continuous_writes, cmd_mongodb_charm) -> None:
-    """Verify unique clusters do not share DBs."""
-    # first find primary, write to primary,
-    await insert_record_in_collection(ops_test)
+# async def test_replication_across_members(ops_test: OpsTest, continuous_writes) -> None:
+#     """Check consistency, ie write to primary, read data from secondaries."""
+#     # verify that the no writes were skipped
+#     await verify_writes(ops_test)
 
-    # deploy new cluster
-    if ANOTHER_DATABASE_APP_NAME not in ops_test.model.applications:
-        await deploy_and_scale_mongodb(
-            ops_test, False, ANOTHER_DATABASE_APP_NAME, 1, cmd_mongodb_charm
+
+# async def test_unique_cluster_dbs(ops_test: OpsTest, continuous_writes, cmd_mongodb_charm) -> None:
+#     """Verify unique clusters do not share DBs."""
+#     # first find primary, write to primary,
+#     await insert_record_in_collection(ops_test)
+
+#     # deploy new cluster
+#     if ANOTHER_DATABASE_APP_NAME not in ops_test.model.applications:
+#         await deploy_and_scale_mongodb(
+#             ops_test, False, ANOTHER_DATABASE_APP_NAME, 1, cmd_mongodb_charm
+#         )
+
+#     # write data to new cluster
+#     with await get_other_mongodb_direct_client(ops_test, ANOTHER_DATABASE_APP_NAME) as client:
+#         db = client["new-db"]
+#         test_collection = db["test_ubuntu_collection"]
+#         test_collection.insert_one({"release_name": "Jammy Jelly", "version": 22.04, "LTS": False})
+
+#         cluster_1_entries = retrieve_entries(
+#             client,
+#             db_name="new-db",
+#             collection_name="test_ubuntu_collection",
+#             query_field="release_name",
+#         )
+#     with await get_mongo_client(ops_test) as client:
+#         cluster_2_entries = retrieve_entries(
+#             client,
+#             db_name="new-db",
+#             collection_name="test_ubuntu_collection",
+#             query_field="release_name",
+#         )
+
+#     common_entries = cluster_2_entries.intersection(cluster_1_entries)
+#     assert len(common_entries) == 0, "Writes from one cluster are replicated to another cluster."
+
+#     # verify that the no writes were skipped
+#     await find_record_in_collection(ops_test)
+#     await verify_writes(ops_test)
+
+
+# async def test_kill_db_process(ops_test: OpsTest, continuous_writes):
+#     # locate primary unit
+#     hostnames = await get_units_hostnames(ops_test)
+#     primary = await get_replica_set_primary(ops_test)
+
+#     mongodb_pid = await get_process_pid(
+#         ops_test, primary.name, MONGODB_CONTAINER_NAME, MONGOD_PROCESS_NAME
+#     )
+
+#     await send_signal_to_pod_container_process(
+#         ops_test,
+#         primary.name,
+#         MONGODB_CONTAINER_NAME,
+#         MONGOD_PROCESS_NAME,
+#         "SIGKILL",
+#     )
+
+#     # sleep for twice the median election time
+#     time.sleep(MEDIAN_REELECTION_TIME * 2)
+
+#     # verify new writes are continuing by counting the number of writes before and after a 5 second
+#     # wait
+#     with await get_mongo_client(ops_test, excluded=[primary.name]) as client:
+#         writes = client[TEST_DB][TEST_COLLECTION].count_documents({})
+#         time.sleep(5)
+#         more_writes = client[TEST_DB][TEST_COLLECTION].count_documents({})
+#     assert more_writes > writes, "writes not continuing to DB"
+
+#     # verify that db service got restarted and is ready
+#     old_primary_unit = int(primary.name.split("/")[1])
+#     assert await mongod_ready(ops_test, old_primary_unit)
+#     new_mongodb_pid = await get_process_pid(
+#         ops_test, primary.name, MONGODB_CONTAINER_NAME, MONGOD_PROCESS_NAME
+#     )
+#     assert (
+#         mongodb_pid != new_mongodb_pid
+#     ), "The mongodb process id is the same after sending it a SIGKILL"
+
+#     # verify that a new primary gets elected (ie old primary is secondary)
+#     new_primary = await get_replica_set_primary(ops_test)
+#     assert (
+#         primary.name != new_primary.name
+#     ), "The mongodb primary has not been reelected after sending a SIGKILL"
+
+#     # verify all units are running under the same replset
+#     member_hosts = await fetch_replica_set_members(ops_test)
+#     assert set(member_hosts) == set(hostnames), "all members not running under the same replset"
+
+#     # verify there is only one primary after killing old primary
+#     assert (
+#         await count_primaries(ops_test) == 1
+#     ), "there are more than one primary in the replica set."
+
+#     # verify that no writes to the db were missed
+#     await verify_writes(ops_test)
+
+
+# async def test_freeze_db_process(ops_test, continuous_writes):
+#     # locate primary unit
+#     hostnames = await get_units_hostnames(ops_test)
+#     primary = await get_replica_set_primary(ops_test)
+
+#     await send_signal_to_pod_container_process(
+#         ops_test,
+#         primary.name,
+#         MONGODB_CONTAINER_NAME,
+#         MONGOD_PROCESS_NAME,
+#         "SIGSTOP",
+#     )
+
+#     # sleep for twice the median election time
+#     time.sleep(MEDIAN_REELECTION_TIME * 2)
+
+#     # verify that a new primary gets elected, old primary is still frozen
+#     new_primary = await get_replica_set_primary(ops_test, excluded=[primary.name])
+#     assert (
+#         primary.name != new_primary.name
+#     ), "The mongodb primary has not been reelected after sending a SIGSTOP"
+
+#     # verify new writes are continuing by counting the number of writes before and after a 5 second
+#     # wait
+#     with await get_mongo_client(ops_test, excluded=[primary.name]) as client:
+#         writes = client[TEST_DB][TEST_COLLECTION].count_documents({})
+#         time.sleep(5)
+#         more_writes = client[TEST_DB][TEST_COLLECTION].count_documents({})
+
+#     # un-freeze the old primary
+#     await send_signal_to_pod_container_process(
+#         ops_test,
+#         primary.name,
+#         MONGODB_CONTAINER_NAME,
+#         MONGOD_PROCESS_NAME,
+#         "SIGCONT",
+#     )
+
+#     # check this after un-freezing the old primary so that if this check fails we still "turned
+#     # back on" the mongod process
+#     assert more_writes > writes, "writes not continuing to DB"
+
+#     # verify that db service got restarted and is ready
+#     old_primary_unit = int(primary.name.split("/")[1])
+#     assert await mongod_ready(ops_test, old_primary_unit)
+
+#     # verify all units are running under the same replset
+#     member_hosts = await fetch_replica_set_members(ops_test)
+#     assert set(member_hosts) == set(hostnames), "all members not running under the same replset"
+
+#     # verify there is only one primary after un-freezing old primary
+#     assert (
+#         await count_primaries(ops_test) == 1
+#     ), "there are more than one primary in the replica set."
+
+#     # verify that the old primary does not "reclaim" primary status after un-freezing old primary
+#     new_primary = await get_replica_set_primary(ops_test)
+#     assert new_primary.name != primary.name, "un-frozen primary should be secondary."
+
+#     # verify that no writes were missed.
+#     await verify_writes(ops_test)
+
+
+# async def test_restart_db_process(ops_test, continuous_writes, change_logging):
+#     # locate primary unit
+#     old_primary = await get_replica_set_primary(ops_test)
+
+#     # send SIGTERM
+#     sig_term_time = datetime.now(timezone.utc)
+#     await send_signal_to_pod_container_process(
+#         ops_test,
+#         old_primary.name,
+#         MONGODB_CONTAINER_NAME,
+#         MONGOD_PROCESS_NAME,
+#         "SIGTERM",
+#     )
+#     # verify that a stepdown was performed on restart. SIGTERM should send a graceful restart and
+#     # send a replica step down signal. Pipes k8s logs output to see if any of the pods received a
+#     # stepdown request. Must be done early otherwise continuous writes may flood the logs
+#     await check_db_stepped_down(ops_test, sig_term_time)
+
+#     # sleep for twice the median election time
+#     time.sleep(MEDIAN_REELECTION_TIME * 2)
+
+#     # verify new writes are continuing by counting the number of writes before and after a 5 second
+#     # wait
+#     with await get_mongo_client(ops_test, excluded=[old_primary.name]) as client:
+#         writes = client[TEST_DB][TEST_COLLECTION].count_documents({})
+#         time.sleep(5)
+#         more_writes = client[TEST_DB][TEST_COLLECTION].count_documents({})
+#     assert more_writes > writes, "writes not continuing to DB"
+
+#     # verify that db service got restarted and is ready
+#     old_primary_unit = int(old_primary.name.split("/")[1])
+#     assert await mongod_ready(ops_test, old_primary_unit)
+
+#     # verify that a new primary gets elected (ie old primary is secondary)
+#     new_primary = await get_replica_set_primary(ops_test)
+#     assert new_primary.name != old_primary.name
+
+#     # verify there is only one primary after killing old primary
+#     assert (
+#         await count_primaries(ops_test) == 1
+#     ), "there are more than one primary in the replica set."
+
+#     # verify that old primary is up to date.
+#     await verify_writes(ops_test)
+
+
+async def test_full_cluster_crash(ops_test: OpsTest, continuous_writes):
+    mongodb_application_name = await get_application_name(ops_test, APP_NAME)
+
+    # update all units to have a new RESTART_DELAY,  Modifying the Restart delay to 3 minutes
+    # should ensure enough time for all replicas to be down at the same time.
+    for unit in ops_test.model.applications[mongodb_application_name].units:
+        modify_pebble_restart_delay(
+            ops_test,
+            unit.name,
+            "tests/integration/ha_tests/manifests/extend_pebble_restart_delay.yml",
+            ensure_replan=True,
         )
 
-    # write data to new cluster
-    with await get_other_mongodb_direct_client(ops_test, ANOTHER_DATABASE_APP_NAME) as client:
-        db = client["new-db"]
-        test_collection = db["test_ubuntu_collection"]
-        test_collection.insert_one({"release_name": "Jammy Jelly", "version": 22.04, "LTS": False})
-
-        cluster_1_entries = retrieve_entries(
-            client,
-            db_name="new-db",
-            collection_name="test_ubuntu_collection",
-            query_field="release_name",
-        )
-    with await get_mongo_client(ops_test) as client:
-        cluster_2_entries = retrieve_entries(
-            client,
-            db_name="new-db",
-            collection_name="test_ubuntu_collection",
-            query_field="release_name",
-        )
-
-    common_entries = cluster_2_entries.intersection(cluster_1_entries)
-    assert len(common_entries) == 0, "Writes from one cluster are replicated to another cluster."
-
-    # verify that the no writes were skipped
-    await find_record_in_collection(ops_test)
-    await verify_writes(ops_test)
-
-
-async def test_kill_db_process(ops_test: OpsTest, continuous_writes):
-    # locate primary unit
-    hostnames = await get_units_hostnames(ops_test)
-    primary = await get_replica_set_primary(ops_test)
-
-    mongodb_pid = await get_process_pid(
-        ops_test, primary.name, MONGODB_CONTAINER_NAME, MONGOD_PROCESS_NAME
+    # kill all units "simultaneously"
+    await asyncio.gather(
+        *[
+            send_signal_to_pod_container_process(
+                ops_test, unit.name, MONGODB_CONTAINER_NAME, MONGOD_PROCESS_NAME, "SIGKILL"
+            )
+            for unit in ops_test.model.applications[mongodb_application_name].units
+        ]
     )
 
-    await send_signal_to_pod_container_process(
-        ops_test,
-        primary.name,
-        MONGODB_CONTAINER_NAME,
-        MONGOD_PROCESS_NAME,
-        "SIGKILL",
-    )
+    # This test serves to verify behavior when all replicas are down at the same time that when
+    # they come back online they operate as expected. This check verifies that we meet the criterea
+    # of all replicas being down at the same time.
+    try:
+        assert await are_all_db_processes_down(
+            ops_test, MONGOD_PROCESS_NAME
+        ), "Not all units down at the same time."
+    finally:
+        # TODO this sets them to a spec restart delay, it would be better to determine the
+        # original delay and revert pebble to that
+        for unit in ops_test.model.applications[mongodb_application_name].units:
+            modify_pebble_restart_delay(
+                ops_test,
+                unit.name,
+                "tests/integration/ha_tests/manifests/restore_pebble_restart_delay.yml",
+                ensure_replan=True,
+            )
 
-    # sleep for twice the median election time
-    time.sleep(MEDIAN_REELECTION_TIME * 2)
+    # sleep for twice the median election time and the restart delay
+    time.sleep(MEDIAN_REELECTION_TIME * 2 + RESTART_DELAY)
+
+    # verify all units are up and running
+    for unit in ops_test.model.applications[mongodb_application_name].units:
+        assert await mongod_ready(ops_test, unit)
 
     # verify new writes are continuing by counting the number of writes before and after a 5 second
     # wait
+    logger.info("Validating writes are continuing to DB")
+    primary = await get_replica_set_primary(ops_test)
     with await get_mongo_client(ops_test, excluded=[primary.name]) as client:
         writes = client[TEST_DB][TEST_COLLECTION].count_documents({})
         time.sleep(5)
         more_writes = client[TEST_DB][TEST_COLLECTION].count_documents({})
     assert more_writes > writes, "writes not continuing to DB"
 
-    # verify that db service got restarted and is ready
-    old_primary_unit = int(primary.name.split("/")[1])
-    assert await mongod_ready(ops_test, old_primary_unit)
-    new_mongodb_pid = await get_process_pid(
-        ops_test, primary.name, MONGODB_CONTAINER_NAME, MONGOD_PROCESS_NAME
-    )
-    assert (
-        mongodb_pid != new_mongodb_pid
-    ), "The mongodb process id is the same after sending it a SIGKILL"
-
-    # verify that a new primary gets elected (ie old primary is secondary)
-    new_primary = await get_replica_set_primary(ops_test)
-    assert (
-        primary.name != new_primary.name
-    ), "The mongodb primary has not been reelected after sending a SIGKILL"
-
     # verify all units are running under the same replset
-    member_hosts = await fetch_replica_set_members(ops_test)
-    assert set(member_hosts) == set(hostnames), "all members not running under the same replset"
-
-    # verify there is only one primary after killing old primary
-    assert (
-        await count_primaries(ops_test) == 1
-    ), "there are more than one primary in the replica set."
-
-    # verify that no writes to the db were missed
-    await verify_writes(ops_test)
-
-
-async def test_freeze_db_process(ops_test, continuous_writes):
-    # locate primary unit
     hostnames = await get_units_hostnames(ops_test)
-    primary = await get_replica_set_primary(ops_test)
-
-    await send_signal_to_pod_container_process(
-        ops_test,
-        primary.name,
-        MONGODB_CONTAINER_NAME,
-        MONGOD_PROCESS_NAME,
-        "SIGSTOP",
-    )
-
-    # sleep for twice the median election time
-    time.sleep(MEDIAN_REELECTION_TIME * 2)
-
-    # verify that a new primary gets elected, old primary is still frozen
-    new_primary = await get_replica_set_primary(ops_test, excluded=[primary.name])
-    assert (
-        primary.name != new_primary.name
-    ), "The mongodb primary has not been reelected after sending a SIGSTOP"
-
-    # verify new writes are continuing by counting the number of writes before and after a 5 second
-    # wait
-    with await get_mongo_client(ops_test, excluded=[primary.name]) as client:
-        writes = client[TEST_DB][TEST_COLLECTION].count_documents({})
-        time.sleep(5)
-        more_writes = client[TEST_DB][TEST_COLLECTION].count_documents({})
-
-    # un-freeze the old primary
-    await send_signal_to_pod_container_process(
-        ops_test,
-        primary.name,
-        MONGODB_CONTAINER_NAME,
-        MONGOD_PROCESS_NAME,
-        "SIGCONT",
-    )
-
-    # check this after un-freezing the old primary so that if this check fails we still "turned
-    # back on" the mongod process
-    assert more_writes > writes, "writes not continuing to DB"
-
-    # verify that db service got restarted and is ready
-    old_primary_unit = int(primary.name.split("/")[1])
-    assert await mongod_ready(ops_test, old_primary_unit)
-
-    # verify all units are running under the same replset
     member_hosts = await fetch_replica_set_members(ops_test)
     assert set(member_hosts) == set(hostnames), "all members not running under the same replset"
 
@@ -338,107 +464,57 @@ async def test_freeze_db_process(ops_test, continuous_writes):
         await count_primaries(ops_test) == 1
     ), "there are more than one primary in the replica set."
 
-    # verify that the old primary does not "reclaim" primary status after un-freezing old primary
-    new_primary = await get_replica_set_primary(ops_test)
-    assert new_primary.name != primary.name, "un-frozen primary should be secondary."
-
     # verify that no writes were missed.
     await verify_writes(ops_test)
 
 
-async def test_restart_db_process(ops_test, continuous_writes, change_logging):
-    # locate primary unit
-    old_primary = await get_replica_set_primary(ops_test)
+# async def test_network_cut(ops_test: OpsTest, continuous_writes, chaos_mesh):
+#     app = await get_application_name(ops_test, APP_NAME)
 
-    # send SIGTERM
-    sig_term_time = datetime.now(timezone.utc)
-    await send_signal_to_pod_container_process(
-        ops_test,
-        old_primary.name,
-        MONGODB_CONTAINER_NAME,
-        MONGOD_PROCESS_NAME,
-        "SIGTERM",
-    )
-    # verify that a stepdown was performed on restart. SIGTERM should send a graceful restart and
-    # send a replica step down signal. Pipes k8s logs output to see if any of the pods received a
-    # stepdown request. Must be done early otherwise continuous writes may flood the logs
-    await check_db_stepped_down(ops_test, sig_term_time)
+#     # retrieve a primary unit and a non-primary unit (active-unit). The primary unit will have its
+#     # network disrupted, while the active unit allows us to communicate to `mongod`
+#     primary = await get_replica_set_primary(ops_test)
+#     active_unit = [
+#         unit for unit in ops_test.model.applications[app].units if unit.name != primary.name
+#     ][0]
 
-    # sleep for twice the median election time
-    time.sleep(MEDIAN_REELECTION_TIME * 2)
+#     # grab unit hosts
+#     hostnames = await get_units_hostnames(ops_test)
 
-    # verify new writes are continuing by counting the number of writes before and after a 5 second
-    # wait
-    with await get_mongo_client(ops_test, excluded=[old_primary.name]) as client:
-        writes = client[TEST_DB][TEST_COLLECTION].count_documents({})
-        time.sleep(5)
-        more_writes = client[TEST_DB][TEST_COLLECTION].count_documents({})
-    assert more_writes > writes, "writes not continuing to DB"
+#     # Create networkchaos policy to isolate instance from cluster
+#     isolate_instance_from_cluster(ops_test, primary.name)
+#     logger.info(f"Primary instance {primary.name} isolated from cluster")
+#     # sleep for twice the median election time
+#     time.sleep(MEDIAN_REELECTION_TIME * 2)
 
-    # verify that db service got restarted and is ready
-    old_primary_unit = int(old_primary.name.split("/")[1])
-    assert await mongod_ready(ops_test, old_primary_unit)
+#     # Wait until Mongodb actually detects isolated instance
+#     logger.info(f"Waiting until Mongodb detects primary instance {primary.name} is not reachable")
+#     await wait_until_unit_in_status(ops_test, primary, active_unit, "(not reachable/healthy)")
 
-    # verify that a new primary gets elected (ie old primary is secondary)
-    new_primary = await get_replica_set_primary(ops_test)
-    assert new_primary.name != old_primary.name
+#     # verify new writes are continuing by counting the number of writes before and after a 5 second
+#     # wait
+#     logger.info("Validating writes are continuing to DB")
+#     with await get_mongo_client(ops_test, excluded=[primary.name]) as client:
+#         writes = client[TEST_DB][TEST_COLLECTION].count_documents({})
+#         time.sleep(5)
+#         more_writes = client[TEST_DB][TEST_COLLECTION].count_documents({})
+#     assert more_writes > writes, "writes not continuing to DB"
 
-    # verify there is only one primary after killing old primary
-    assert (
-        await count_primaries(ops_test) == 1
-    ), "there are more than one primary in the replica set."
+#     # verify that a new primary got elected, old primary is still cut off
+#     new_primary = await get_replica_set_primary(ops_test, excluded=[primary.name])
+#     assert new_primary.name != primary.name
 
-    # verify that old primary is up to date.
-    await verify_writes(ops_test)
+#     # Remove networkchaos policy isolating instance from cluster
+#     remove_instance_isolation(ops_test)
 
+#     await wait_until_unit_in_status(ops_test, primary, active_unit, "SECONDARY")
 
-async def test_network_cut(ops_test: OpsTest, continuous_writes, chaos_mesh):
-    app = await get_application_name(ops_test, APP_NAME)
+#     # verify presence of primary, replica set member configuration, and number of primaries
+#     member_hosts = await fetch_replica_set_members(ops_test)
+#     assert set(member_hosts) == set(hostnames)
+#     assert (
+#         await count_primaries(ops_test) == 1
+#     ), "there is more than one primary in the replica set."
 
-    # retrieve a primary unit and a non-primary unit (active-unit). The primary unit will have its
-    # network disrupted, while the active unit allows us to communicate to `mongod`
-    primary = await get_replica_set_primary(ops_test)
-    active_unit = [
-        unit for unit in ops_test.model.applications[app].units if unit.name != primary.name
-    ][0]
-
-    # grab unit hosts
-    hostnames = await get_units_hostnames(ops_test)
-
-    # Create networkchaos policy to isolate instance from cluster
-    isolate_instance_from_cluster(ops_test, primary.name)
-    logger.info(f"Primary instance {primary.name} isolated from cluster")
-    # sleep for twice the median election time
-    time.sleep(MEDIAN_REELECTION_TIME * 2)
-
-    # Wait until Mongodb actually detects isolated instance
-    logger.info(f"Waiting until Mongodb detects primary instance {primary.name} is not reachable")
-    await wait_until_unit_in_status(ops_test, primary, active_unit, "(not reachable/healthy)")
-
-    # verify new writes are continuing by counting the number of writes before and after a 5 second
-    # wait
-    logger.info("Validating writes are continuing to DB")
-    with await get_mongo_client(ops_test, excluded=[primary.name]) as client:
-        writes = client[TEST_DB][TEST_COLLECTION].count_documents({})
-        time.sleep(5)
-        more_writes = client[TEST_DB][TEST_COLLECTION].count_documents({})
-    assert more_writes > writes, "writes not continuing to DB"
-
-    # verify that a new primary got elected, old primary is still cut off
-    new_primary = await get_replica_set_primary(ops_test, excluded=[primary.name])
-    assert new_primary.name != primary.name
-
-    # Remove networkchaos policy isolating instance from cluster
-    remove_instance_isolation(ops_test)
-
-    await wait_until_unit_in_status(ops_test, primary, active_unit, "SECONDARY")
-
-    # verify presence of primary, replica set member configuration, and number of primaries
-    member_hosts = await fetch_replica_set_members(ops_test)
-    assert set(member_hosts) == set(hostnames)
-    assert (
-        await count_primaries(ops_test) == 1
-    ), "there is more than one primary in the replica set."
-
-    # verify that old primary is up to date.
-    await verify_writes(ops_test)
+#     # verify that old primary is up to date.
+#     await verify_writes(ops_test)

--- a/tox.ini
+++ b/tox.ini
@@ -79,7 +79,7 @@ pass_env =
     CI_PACKED_CHARMS
 commands_pre =
     poetry install --with integration
-    poetry run pip install juju==2.9.44.0
+    poetry run pip install juju==3.2.0.1
 commands =
     poetry run pytest -v --tb native --log-cli-level=INFO -s --durations=0 {posargs} {[vars]tests_path}/integration/ha_tests/test_ha.py
 

--- a/tox.ini
+++ b/tox.ini
@@ -79,7 +79,7 @@ pass_env =
     CI_PACKED_CHARMS
 commands_pre =
     poetry install --with integration
-    poetry run pip install juju==3.2.0.1
+    poetry run pip install juju==2.9.44.0
 commands =
     poetry run pytest -v --tb native --log-cli-level=INFO -s --durations=0 {posargs} {[vars]tests_path}/integration/ha_tests/test_ha.py
 


### PR DESCRIPTION
## Problem
Current HA test suite doesnt have a full cluster crash test

## Solution
Add full cluster crash test

## Reused code
Code from the Postgres repo that changes the pebble layer was ported over (i.e. all the changes in `helpers`)

## Additional Context
to get this test to function properly, some modifications were needed in continuous writes. Specifically we must try again when the HMAC is out of sync between the client and the cluster. The reasoning for this was discussed in Mattermost but is pasted below:

I'm running into the issue that @dragop ran into when he first attempted to do [full cluster crash test](https://github.com/canonical/mongodb-k8s-operator/pull/80) which is:

> Cluster crash/restart currently fail the assertion for total writes, meaning that the DB didn't persist some of the writes `continuous_writes.py` thinks it should have.
The cause for the mismatch seems to be a PyMongo OperationError thrown while restarted nodes rejoin the cluster with the following message:
```
No keys found for HMAC that is valid for time: { ts: Timestamp(1669922958, 10) } with id: 7172123513443057669, full error: {'ok': 0.0, 'errmsg': 'No keys found for HMAC that is valid for time: { ts: Timestamp(1669922958, 10) } with id: 7172123513443057669', 'code': 211, 'codeName': 'KeyNotFound'}
```

After some googling, I *think* that vector clock cluster time is out of sync, between the replicas and the client. (This would make sense since we shutdown the `mongod` process on all replicas and I assume the client needs to get insync again). From Wiki:
> In [cryptography](https://en.wikipedia.org/wiki/Cryptography "Cryptography"), an **HMAC** (sometimes expanded as either **keyed-hash message authentication code** or **hash-based message authentication code**) is a specific type of [message authentication code](https://en.wikipedia.org/wiki/Message_authentication_code "Message authentication code") (MAC) involving a cryptographic hash function and a secret cryptographic key. As with any MAC, it may be used to simultaneously verify both the data integrity and authenticity of a message.

According to the [MongoDB Docs](https://www.mongodb.com/docs/v5.0/core/security-client-side-encryption/#encryption-algorithms) , HMAC encryption is used on the *client side*, so my theory is that the client that we use to write to MongoDB has out of date HMAC keys, (due to the cluster going down and then being available again). 

From what I can tell in my testing by hand is that we miss only one write to the DB, so I assume that the client only *temporarily* has out of date HMAC keys, and that is resolves this and writes continue. After all, the test does show that writes continue to the DB after the cluster comes back up. 

I believe *This is NOT an issue with the MongoDB cluster. The correct way to handle this is on the client side.**  i.e. when we encounter an HMAC error the client should try again. 

more reading shows this error in the logs on the cluster side:
```
  "id":4939300, "ctx":"monitoring-keys-for-HMAC","msg":"Failed to refresh key cache","attr":{"error":"ReadConcernMajorityNotAvailableYet: Read concern majority reads are currently not possible.","nextWakeupMillis":600}}
```
so I think that when the replica set slowly comes back up and gets reconfigured, there is a moment where the HMAC key is out of date on the replica set side. **AFAICT this is reasonable and to be expected, since the replica set needs to get back in sync. I don't think we can expect the replica set to restart and immediately have the correct HMAC key** 

This reasoning was then verified by Mykola