### PR TITLE
Update link to the documentation for MongoDB 5 charm

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -9,7 +9,7 @@ description: |
   charm deploys and operates MongoDB on kubernetes Clusters. It
   supports replicated MongoDB databases.
 summary: A MongoDB operator charm for Kubernetes
-docs: https://discourse.charmhub.io/t/charmed-mongodb-k8s-docs/10265
+docs: https://discourse.charmhub.io/t/charmed-mongodb-5-k8s-docs/12484
 source: https://github.com/canonical/mongodb-k8s-operator
 issues: https://github.com/canonical/mongodb-k8s-operator/issues
 website:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,8 +10,8 @@ authors = [
 ]
 license = "Apache-2.0"
 readme = "README.md"
-homepage = "TODO"
-repository = "TODO"
+homepage = "https://python-poetry.org/"
+repository = "https://github.com/python-poetry/poetry"
 
 [tool.poetry.dependencies]
 python = "^3.8.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,8 +10,8 @@ authors = [
 ]
 license = "Apache-2.0"
 readme = "README.md"
-homepage = "https://python-poetry.org/"
-repository = "https://github.com/python-poetry/poetry"
+homepage = "https://charmhub.io/mongodb-k8s?channel=5/edge"
+repository = "https://github.com/canonical/mongodb-k8s-operator"
 
 [tool.poetry.dependencies]
 python = "^3.8.10"


### PR DESCRIPTION
# Issue

After publishing a new charm with MongoDB 6 we need to support different docs sets for different version of charms.


# Solution

Update link to documentation set in metadata.yaml