### PR TITLE
Split cluster initialisation into two parts

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -344,6 +344,7 @@ class MongoDBCharm(CharmBase):
 
     def _on_start(self, event) -> None:
         """Initialise MongoDB.
+
         Initialisation of replSet should be made once after start.
         MongoDB needs some time to become fully started.
         This event handler is deferred if initialisation of MongoDB
@@ -359,7 +360,6 @@ class MongoDBCharm(CharmBase):
         It is needed to install mongodb-clients inside the charm container
         to make this function work correctly.
         """
-
         container = self.unit.get_container(Config.CONTAINER_NAME)
         if not container.can_connect():
             logger.debug("mongod container is not ready yet.")

--- a/src/charm.py
+++ b/src/charm.py
@@ -344,7 +344,6 @@ class MongoDBCharm(CharmBase):
 
     def _on_start(self, event) -> None:
         """Initialise MongoDB.
-
         Initialisation of replSet should be made once after start.
         MongoDB needs some time to become fully started.
         This event handler is deferred if initialisation of MongoDB

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -295,6 +295,7 @@ class TestCharm(unittest.TestCase):
         self.harness.charm.unit.get_container = mock_container
 
         self.harness.charm.app_peer_data["db_initialised"] = "True"
+        self.harness.charm.app_peer_data["users_initialized"] = "True"
 
         self.harness.charm.on.start.emit()
 
@@ -394,7 +395,7 @@ class TestCharm(unittest.TestCase):
         defer.assert_called()
 
         # verify app data
-        self.assertEqual("db_initialised" in self.harness.charm.app_peer_data, False)
+        self.assertEqual("users_initialized" in self.harness.charm.app_peer_data, False)
 
     @patch("ops.framework.EventBase.defer")
     @patch("charm.MongoDBProvider")
@@ -423,7 +424,7 @@ class TestCharm(unittest.TestCase):
             defer.assert_called()
 
             # verify app data
-            self.assertEqual("db_initialised" in self.harness.charm.app_peer_data, False)
+            self.assertEqual("users_initialized" in self.harness.charm.app_peer_data, False)
 
     @patch("ops.framework.EventBase.defer")
     @patch("charm.MongoDBConnection")


### PR DESCRIPTION
## About
Sometimes MongoDB need more time to initialise replica set an this can lead to a race condition and failure on user creation.

## Solution
Split `_initialise_replica_set` function into two parts:
1. Cluster initialisation
2. User creation

and add retries for user creation