### PR TITLE
Split cluster initialisation into two parts: cluster initialisation and user creation

### DIFF
--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -295,6 +295,7 @@ class TestCharm(unittest.TestCase):
         self.harness.charm.unit.get_container = mock_container
 
         self.harness.charm.app_peer_data["db_initialised"] = "True"
+        self.harness.charm.app_peer_data["users_initialized"] = "True"
 
         self.harness.charm.on.start.emit()
 
@@ -394,7 +395,7 @@ class TestCharm(unittest.TestCase):
         defer.assert_called()
 
         # verify app data
-        self.assertEqual("db_initialised" in self.harness.charm.app_peer_data, False)
+        self.assertEqual("users_initialized" in self.harness.charm.app_peer_data, False)
 
     @patch("ops.framework.EventBase.defer")
     @patch("charm.MongoDBProvider")
@@ -423,7 +424,7 @@ class TestCharm(unittest.TestCase):
             defer.assert_called()
 
             # verify app data
-            self.assertEqual("db_initialised" in self.harness.charm.app_peer_data, False)
+            self.assertEqual("users_initialized" in self.harness.charm.app_peer_data, False)
 
     @patch("ops.framework.EventBase.defer")
     @patch("charm.MongoDBConnection")


### PR DESCRIPTION
## About
Sometimes MongoDB need more time to initialise replica set an this can lead to a race condition and failure on user creation.

## Solution
Split `_initialise_replica_set` function into two parts:
1. Cluster initialisation
2. User creation

and add retries for user creation