### PR TITLE
[DPE-2910] Enable audit logging

### DIFF
--- a/lib/charms/mongodb/v0/helpers.py
+++ b/lib/charms/mongodb/v0/helpers.py
@@ -45,7 +45,7 @@ MONGODB_SNAP_DATA_DIR = "/var/snap/charmed-mongodb/current"
 
 DATA_DIR = "/var/lib/mongodb"
 CONF_DIR = "/etc/mongod"
-LOG_DIR = "/var/log/mongodb"
+LOG_DIR = "/var/lib/mongodb"
 MONGODB_LOG_FILENAME = "mongodb.log"
 logger = logging.getLogger(__name__)
 

--- a/lib/charms/mongodb/v0/helpers.py
+++ b/lib/charms/mongodb/v0/helpers.py
@@ -19,6 +19,8 @@ from ops.model import (
 )
 from pymongo.errors import AutoReconnect, ServerSelectionTimeoutError
 
+from config import Config
+
 # The unique Charmhub library identifier, never change it
 LIBID = "b9a7fe0c38d8486a9d1ce94c27d4758e"
 
@@ -43,6 +45,7 @@ MONGODB_SNAP_DATA_DIR = "/var/snap/charmed-mongodb/current"
 
 DATA_DIR = "/var/lib/mongodb"
 CONF_DIR = "/etc/mongod"
+LOG_DIR = "/var/log/mongodb"
 MONGODB_LOG_FILENAME = "mongodb.log"
 logger = logging.getLogger(__name__)
 
@@ -92,9 +95,10 @@ def get_mongod_args(
     """
     full_data_dir = f"{MONGODB_COMMON_DIR}{DATA_DIR}" if snap_install else DATA_DIR
     full_conf_dir = f"{MONGODB_SNAP_DATA_DIR}{CONF_DIR}" if snap_install else CONF_DIR
+    full_log_dir = f"{MONGODB_SNAP_DATA_DIR}{LOG_DIR}" if snap_install else LOG_DIR
     # in k8s the default logging options that are used for the vm charm are ignored and logs are
     # the output of the container. To enable logging to a file it must be set explicitly
-    logging_options = "" if snap_install else f"--logpath={full_data_dir}/{MONGODB_LOG_FILENAME}"
+    logging_options = "" if snap_install else f"--logpath={full_log_dir}/{MONGODB_LOG_FILENAME}"
     cmd = [
         # bind to localhost and external interfaces
         "--bind_ip_all",
@@ -102,6 +106,9 @@ def get_mongod_args(
         f"--replSet={config.replset}",
         # db must be located within the snap common directory since the snap is strictly confined
         f"--dbpath={full_data_dir}",
+        "--auditDestination=file",
+        f"--auditFormat={Config.AuditLog.FORMAT}",
+        f"--auditPath={full_log_dir}/{Config.AuditLog.FILE_NAME}",
         logging_options,
     ]
     if auth:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -46,6 +46,8 @@ containers:
     mounts:
       - storage: mongodb
         location: /var/lib/mongodb
+      - storage: mongodb-logs
+        location: /var/log/mongodb
 resources:
   mongodb-image:
     type: oci-image
@@ -55,4 +57,6 @@ storage:
   mongodb:
     type: filesystem
     location: /var/lib/mongodb
-  
+  mongodb-logs:
+    type: filesystem
+    location: /var/log/mongodb

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -46,8 +46,6 @@ containers:
     mounts:
       - storage: mongodb
         location: /var/lib/mongodb
-      - storage: mongodb-logs
-        location: /var/log/mongodb
 resources:
   mongodb-image:
     type: oci-image
@@ -57,6 +55,3 @@ storage:
   mongodb:
     type: filesystem
     location: /var/lib/mongodb
-  mongodb-logs:
-    type: filesystem
-    location: /var/log/mongodb

--- a/src/charm.py
+++ b/src/charm.py
@@ -129,7 +129,7 @@ class MongoDBCharm(CharmBase):
         self.grafana_dashboards = GrafanaDashboardProvider(self)
         self.loki_push = LogProxyConsumer(
             self,
-            log_files=Config.LOG_FILES,
+            log_files=Config.get_logs_files_paths(),
             relation_name=Config.Relations.LOGGING,
             container_name=Config.CONTAINER_NAME,
         )

--- a/src/config.py
+++ b/src/config.py
@@ -13,7 +13,7 @@ class Config:
     UNIX_USER = "mongodb"
     UNIX_GROUP = "mongodb"
     DATA_DIR = "/var/lib/mongodb"
-    LOG_DIR = "/var/log/mongodb"
+    LOG_DIR = "/var/lib/mongodb"
     CONF_DIR = "/etc/mongod"
     MONGODB_LOG_FILENAME = "mongodb.log"
     LICENSE_PATH = "/licenses/LICENSE"

--- a/src/config.py
+++ b/src/config.py
@@ -2,7 +2,7 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-from typing import Literal
+from typing import List, Literal
 
 
 class Config:
@@ -13,9 +13,9 @@ class Config:
     UNIX_USER = "mongodb"
     UNIX_GROUP = "mongodb"
     DATA_DIR = "/var/lib/mongodb"
+    LOG_DIR = "/var/log/mongodb"
     CONF_DIR = "/etc/mongod"
     MONGODB_LOG_FILENAME = "mongodb.log"
-    LOG_FILES = [f"{DATA_DIR}/{MONGODB_LOG_FILENAME}"]
     LICENSE_PATH = "/licenses/LICENSE"
     CONTAINER_NAME = "mongod"
     SERVICE_NAME = "mongod"
@@ -23,11 +23,18 @@ class Config:
     APP_SCOPE = "app"
     UNIT_SCOPE = "unit"
 
+    # Keep these alphabetically sorted
     class Actions:
         """Actions related config for MongoDB Charm."""
 
         PASSWORD_PARAM_NAME = "password"
         USERNAME_PARAM_NAME = "username"
+
+    class AuditLog:
+        """Audit log related configuration."""
+
+        FORMAT = "JSON"
+        FILE_NAME = "audit.log"
 
     class Backup:
         """Backup related config for MongoDB Charm."""
@@ -95,3 +102,11 @@ class Config:
     def get_license_path(license_name: str) -> str:
         """Return the path to the license file."""
         return f"{Config.LICENSE_PATH}-{license_name}"
+
+    @staticmethod
+    def get_logs_files_paths() -> List[str]:
+        """Returns list of paths to mongodb related log files."""
+        return [
+            f"{Config.LOG_DIR}/{Config.MONGODB_LOG_FILENAME}",
+            f"{Config.LOG_DIR}/{Config.AuditLog.FILE_NAME}",
+        ]

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -76,8 +76,8 @@ class TestCharm(unittest.TestCase):
                         f"--dbpath={DATA_DIR} "
                         "--auditDestination=file "
                         "--auditFormat=JSON "
-                        "--auditPath=/var/log/mongodb/audit.log "
-                        "--logpath=/var/log/mongodb/mongodb.log --auth "
+                        "--auditPath=/var/lib/mongodb/audit.log "
+                        "--logpath=/var/lib/mongodb/mongodb.log --auth "
                         "--clusterAuthMode=keyFile "
                         f"--keyFile={CONF_DIR}/{KEY_FILE} \n"
                     ),

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -74,7 +74,10 @@ class TestCharm(unittest.TestCase):
                         "mongod --bind_ip_all "
                         "--replSet=mongodb-k8s "
                         f"--dbpath={DATA_DIR} "
-                        "--logpath=/var/lib/mongodb/mongodb.log --auth "
+                        "--auditDestination=file "
+                        "--auditFormat=JSON "
+                        "--auditPath=/var/log/mongodb/audit.log "
+                        "--logpath=/var/log/mongodb/mongodb.log --auth "
                         "--clusterAuthMode=keyFile "
                         f"--keyFile={CONF_DIR}/{KEY_FILE} \n"
                     ),


### PR DESCRIPTION
## About

The goal of this PR is to enable audit logging for Charmed MongoDB K8s and add audit logs to CoS

## Audit log
<img width="957" alt="Screenshot 2024-01-19 at 16 45 30" src="https://github.com/canonical/mongodb-k8s-operator/assets/132273757/975150a1-6a13-4e1a-9be9-cf7057c2ded3">
