### PR TITLE
[DPE-3290] Run integration tests on existing cluster

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,7 +56,7 @@ jobs:
       fail-fast: false
       matrix:
         tox-environments:
-          - integration
+          - charm-integration
           - ha-integration
           - tls-integration
           - metrics-integration

--- a/tests/integration/backup_tests/test_backups.py
+++ b/tests/integration/backup_tests/test_backups.py
@@ -33,7 +33,7 @@ logger = logging.getLogger(__name__)
 @pytest_asyncio.fixture
 async def continuous_writes_to_db(ops_test: OpsTest):
     """Continuously writes to DB for the duration of the test."""
-    application_name = ha_helpers.get_application_name(ops_test, "application")
+    application_name = await ha_helpers.get_application_name(ops_test, "application")
 
     application_unit = ops_test.model.applications[application_name].units[0]
 
@@ -52,7 +52,7 @@ async def continuous_writes_to_db(ops_test: OpsTest):
 @pytest_asyncio.fixture
 async def add_writes_to_db(ops_test: OpsTest):
     """Adds writes to DB before test starts and clears writes at the end of the test."""
-    application_name = ha_helpers.get_application_name(ops_test, "application")
+    application_name = await ha_helpers.get_application_name(ops_test, "application")
     application_unit = ops_test.model.applications[application_name].units[0]
 
     clear_writes_action = await application_unit.run_action("clear-continuous-writes")

--- a/tests/integration/backup_tests/test_backups.py
+++ b/tests/integration/backup_tests/test_backups.py
@@ -33,7 +33,7 @@ logger = logging.getLogger(__name__)
 @pytest_asyncio.fixture
 async def continuous_writes_to_db(ops_test: OpsTest):
     """Continuously writes to DB for the duration of the test."""
-    application_name = await get_app_name(ops_test) or "application"
+    application_name = ha_helpers.get_application_name(ops_test, "application")
 
     application_unit = ops_test.model.applications[application_name].units[0]
 
@@ -52,7 +52,7 @@ async def continuous_writes_to_db(ops_test: OpsTest):
 @pytest_asyncio.fixture
 async def add_writes_to_db(ops_test: OpsTest):
     """Adds writes to DB before test starts and clears writes at the end of the test."""
-    application_name = await get_app_name(ops_test) or "application"
+    application_name = ha_helpers.get_application_name(ops_test, "application")
     application_unit = ops_test.model.applications[application_name].units[0]
 
     clear_writes_action = await application_unit.run_action("clear-continuous-writes")

--- a/tests/integration/ha_tests/helpers.py
+++ b/tests/integration/ha_tests/helpers.py
@@ -652,9 +652,13 @@ def isolate_instance_from_cluster(ops_test: OpsTest, unit_name: str) -> None:
         # Apply the generated manifest, chaosmesh would then make the pod inaccessible
         env = os.environ
         env["KUBECONFIG"] = os.path.expanduser("~/.kube/config")
-        subprocess.check_output(
-            " ".join(["microk8s", "kubectl", "apply", "-f", temp_file.name]), shell=True, env=env
+        command_result = subprocess.check_output(
+            " ".join(["microk8s", "kubectl", "apply", "-f", temp_file.name]),
+            shell=True,
+            env=env,
+            stderr=subprocess.STDOUT,
         )
+        logger.info("Result of isolating unit from cluster is '%s'", command_result)
 
 
 def remove_instance_isolation(ops_test: OpsTest) -> None:

--- a/tests/integration/ha_tests/test_ha.py
+++ b/tests/integration/ha_tests/test_ha.py
@@ -10,7 +10,7 @@ import pytest
 import pytest_asyncio
 from pytest_operator.plugin import OpsTest
 
-from ..helpers import APP_NAME
+from ..helpers import APP_NAME, check_or_scale_app
 from .helpers import (
     ANOTHER_DATABASE_APP_NAME,
     MONGOD_PROCESS_NAME,
@@ -111,10 +111,15 @@ async def test_build_and_deploy(ops_test: OpsTest, cmd_mongodb_charm) -> None:
     # it is possible for users to provide their own cluster for HA testing. Hence check if there
     # is a pre-existing cluster.
     mongodb_application_name = await get_application_name(ops_test, APP_NAME)
+
+    num_units = 3
     if not mongodb_application_name:
         mongodb_application_name = await deploy_and_scale_mongodb(
-            ops_test, charm_path=cmd_mongodb_charm
+            ops_test, charm_path=cmd_mongodb_charm, num_units=num_units
         )
+    else:
+        check_or_scale_app(ops_test, mongodb_application_name, num_units)
+
     application_name = await get_application_name(ops_test, "application")
     if not application_name:
         application_name = await deploy_and_scale_application(ops_test)

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -180,7 +180,7 @@ async def run_mongo_op(
 
     output.succeeded = True
     if expecting_output:
-        output.data = _process_mongo_operation_result(stdout, stderr)
+        output.data = _process_mongo_operation_result(stdout, stderr, expect_json_load)
     logger.info("Done: '%s'", output)
     return output
 

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -49,7 +49,6 @@ logger = logging.getLogger(__name__)
 
 async def get_leader_id(ops_test: OpsTest, app_name: str = APP_NAME) -> int:
     """Returns the unit number of the juju leader unit."""
-
     for unit in ops_test.model.applications[app_name].units:
         if await unit.is_leader_from_status():
             return int(unit.entity_id.split("/")[-1])

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -513,3 +513,4 @@ async def check_or_scale_app(ops_test: OpsTest, user_app_name: str, required_uni
         return
     count = required_units - current_units
     await ops_test.model.applications[user_app_name].scale(scale_change=count)
+    await ops_test.model.wait_for_idle(apps=[user_app_name], status="active", timeout=2000)

--- a/tests/integration/metrics_tests/test_metrics.py
+++ b/tests/integration/metrics_tests/test_metrics.py
@@ -56,7 +56,6 @@ async def test_build_and_deploy(ops_test: OpsTest) -> None:
     """Build and deploy three units of MongoDB and one unit of TLS."""
     # no need to build and deploy charm if provided
     app_name = await get_app_name(ops_test)
-    num_units = NUM_UNITS
     if app_name:
         return await check_or_scale_app(ops_test, app_name, NUM_UNITS)
 
@@ -64,7 +63,7 @@ async def test_build_and_deploy(ops_test: OpsTest) -> None:
         my_charm = await ops_test.build_charm(".")
         resources = {"mongodb-image": METADATA["resources"]["mongodb-image"]["upstream-source"]}
         await ops_test.model.deploy(
-            my_charm, num_units=num_units, resources=resources, series="jammy"
+            my_charm, num_units=NUM_UNITS, resources=resources, series="jammy"
         )
         await ops_test.model.wait_for_idle(apps=[DATABASE_APP_NAME], status="active", timeout=2000)
 

--- a/tests/integration/metrics_tests/test_metrics.py
+++ b/tests/integration/metrics_tests/test_metrics.py
@@ -17,6 +17,7 @@ DATABASE_APP_NAME = "mongodb-k8s"
 MONGODB_EXPORTER_PORT = 9216
 MEDIAN_REELECTION_TIME = 12
 RESTART_TIMEOUT = 10
+NUM_UNITS = 3
 
 
 @pytest.fixture(scope="module")
@@ -55,9 +56,9 @@ async def test_build_and_deploy(ops_test: OpsTest) -> None:
     """Build and deploy three units of MongoDB and one unit of TLS."""
     # no need to build and deploy charm if provided
     app_name = await get_app_name(ops_test)
-    num_units = 3
+    num_units = NUM_UNITS
     if app_name:
-        return await check_or_scale_app(ops_test, app_name, num_units)
+        return await check_or_scale_app(ops_test, app_name, NUM_UNITS)
 
     async with ops_test.fast_forward():
         my_charm = await ops_test.build_charm(".")

--- a/tests/integration/metrics_tests/test_metrics.py
+++ b/tests/integration/metrics_tests/test_metrics.py
@@ -75,13 +75,13 @@ async def test_build_and_deploy(ops_test: OpsTest) -> None:
 
 async def test_endpoints(ops_test: OpsTest):
     """Sanity check that endpoints are running."""
-    app_name = await get_app_name(ops_test) or DATABASE_APP_NAME
+    app_name = await get_app_name(ops_test)
     await verify_endpoints(ops_test, app_name)
 
 
 async def test_endpoints_new_password(ops_test: OpsTest):
     """Verify that endpoints still function correctly after the monitor user password changes."""
-    app_name = await get_app_name(ops_test) or DATABASE_APP_NAME
+    app_name = await get_app_name(ops_test)
     leader_unit = await ha_helpers.find_unit(ops_test, leader=True)
     action = await leader_unit.run_action("set-password", **{"username": "monitor"})
     action = await action.wait()
@@ -96,7 +96,7 @@ async def test_endpoints_network_cut(ops_test: OpsTest, chaos_mesh):
     """Verify that endpoint still function correctly after a network cut."""
     # retrieve a primary unit and a non-primary unit (active-unit). The primary unit will have its
     # network disrupted, while the active unit allows us to communicate to `mongod`
-    app_name = await get_app_name(ops_test) or DATABASE_APP_NAME
+    app_name = await get_app_name(ops_test)
     primary = await ha_helpers.get_replica_set_primary(ops_test)
     active_unit = [
         unit for unit in ops_test.model.applications[app_name].units if unit.name != primary.name

--- a/tests/integration/metrics_tests/test_metrics.py
+++ b/tests/integration/metrics_tests/test_metrics.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python3
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
+import os
 import time
 from pathlib import Path
 
 import pytest
+from ..helpers import check_or_scale_app, get_app_name
 import urllib3
 import yaml
 from pytest_operator.plugin import OpsTest
@@ -49,30 +51,41 @@ async def verify_endpoints(ops_test: OpsTest, app_name=DATABASE_APP_NAME):
     assert mongodb_metrics.count("mongo") > 10
 
 
+@pytest.mark.skipif(
+    os.environ.get("PYTEST_SKIP_DEPLOY", False),
+    reason="skipping deploy, model expected to be provided.",
+)
 @pytest.mark.abort_on_fail
 async def test_build_and_deploy(ops_test: OpsTest) -> None:
     """Build and deploy three units of MongoDB and one unit of TLS."""
     # no need to build and deploy charm if provided
-    mongodb_application_name = await ha_helpers.get_application_name(ops_test, DATABASE_APP_NAME)
-    if mongodb_application_name:
-        return
+    app_name = await get_app_name(ops_test)
+    num_units = 3
+    if app_name:
+        return await check_or_scale_app(ops_test, app_name, num_units)
 
     async with ops_test.fast_forward():
         my_charm = await ops_test.build_charm(".")
         resources = {"mongodb-image": METADATA["resources"]["mongodb-image"]["upstream-source"]}
-        await ops_test.model.deploy(my_charm, num_units=3, resources=resources, series="jammy")
+        await ops_test.model.deploy(my_charm, num_units=num_units, resources=resources, series="jammy")
         await ops_test.model.wait_for_idle(apps=[DATABASE_APP_NAME], status="active", timeout=2000)
 
 
 async def test_endpoints(ops_test: OpsTest):
     """Sanity check that endpoints are running."""
-    mongodb_application_name = await ha_helpers.get_application_name(ops_test, DATABASE_APP_NAME)
-    await verify_endpoints(ops_test, mongodb_application_name)
+    app_name = (
+        await get_app_name(ops_test)
+        or DATABASE_APP_NAME
+    )
+    await verify_endpoints(ops_test, app_name)
 
 
 async def test_endpoints_new_password(ops_test: OpsTest):
     """Verify that endpoints still function correctly after the monitor user password changes."""
-    mongodb_application_name = await ha_helpers.get_application_name(ops_test, DATABASE_APP_NAME)
+    app_name = (
+        await get_app_name(ops_test)
+        or DATABASE_APP_NAME
+    )
     leader_unit = await ha_helpers.find_unit(ops_test, leader=True)
     action = await leader_unit.run_action("set-password", **{"username": "monitor"})
     action = await action.wait()
@@ -80,18 +93,21 @@ async def test_endpoints_new_password(ops_test: OpsTest):
     time.sleep(RESTART_TIMEOUT)
     await ops_test.model.wait_for_idle()
 
-    await verify_endpoints(ops_test, mongodb_application_name)
+    await verify_endpoints(ops_test, app_name)
 
 
 async def test_endpoints_network_cut(ops_test: OpsTest, chaos_mesh):
     """Verify that endpoint still function correctly after a network cut."""
     # retrieve a primary unit and a non-primary unit (active-unit). The primary unit will have its
     # network disrupted, while the active unit allows us to communicate to `mongod`
-    mongodb_application_name = await ha_helpers.get_application_name(ops_test, DATABASE_APP_NAME)
+    app_name = (
+        await get_app_name(ops_test)
+        or DATABASE_APP_NAME
+    )
     primary = await ha_helpers.get_replica_set_primary(ops_test)
     active_unit = [
         unit
-        for unit in ops_test.model.applications[mongodb_application_name].units
+        for unit in ops_test.model.applications[app_name].units
         if unit.name != primary.name
     ][0]
 
@@ -110,4 +126,4 @@ async def test_endpoints_network_cut(ops_test: OpsTest, chaos_mesh):
     # Wait for the network to be restored
     await ha_helpers.wait_until_unit_in_status(ops_test, primary, active_unit, "SECONDARY")
 
-    await verify_endpoints(ops_test, mongodb_application_name)
+    await verify_endpoints(ops_test, app_name)

--- a/tests/integration/metrics_tests/test_metrics.py
+++ b/tests/integration/metrics_tests/test_metrics.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
-import os
 import time
 from pathlib import Path
 
@@ -51,10 +50,6 @@ async def verify_endpoints(ops_test: OpsTest, app_name=DATABASE_APP_NAME):
     assert mongodb_metrics.count("mongo") > 10
 
 
-@pytest.mark.skipif(
-    os.environ.get("PYTEST_SKIP_DEPLOY", False),
-    reason="skipping deploy, model expected to be provided.",
-)
 @pytest.mark.abort_on_fail
 async def test_build_and_deploy(ops_test: OpsTest) -> None:
     """Build and deploy three units of MongoDB and one unit of TLS."""

--- a/tests/integration/relation_tests/test_charm_relations.py
+++ b/tests/integration/relation_tests/test_charm_relations.py
@@ -3,7 +3,6 @@
 # See LICENSE file for licensing details.
 import asyncio
 import logging
-import os
 import time
 from pathlib import Path
 

--- a/tests/integration/relation_tests/test_charm_relations.py
+++ b/tests/integration/relation_tests/test_charm_relations.py
@@ -81,7 +81,7 @@ async def test_deploy_charms(ops_test: OpsTest):
         ),
     )
 
-APP_NAMES.append(await get_app_name(ops_test, test_deployments=[ANOTHER_DATABASE_APP_NAME]))
+    APP_NAMES.append(await get_app_name(ops_test, test_deployments=[ANOTHER_DATABASE_APP_NAME]))
     await ops_test.model.wait_for_idle(apps=APP_NAMES, status="active", timeout=1000)
 
 

--- a/tests/integration/relation_tests/test_charm_relations.py
+++ b/tests/integration/relation_tests/test_charm_relations.py
@@ -38,10 +38,6 @@ TEST_APP_CHARM_PATH = "tests/integration/relation_tests/application-charm"
 REQUIRED_UNITS = 2
 
 
-@pytest.mark.skipif(
-    os.environ.get("PYTEST_SKIP_DEPLOY", False),
-    reason="skipping deploy, model expected to be provided.",
-)
 @pytest.mark.abort_on_fail
 async def test_deploy_charms(ops_test: OpsTest):
     """Deploy both charms (application and database) to use in the tests."""

--- a/tests/integration/relation_tests/test_charm_relations.py
+++ b/tests/integration/relation_tests/test_charm_relations.py
@@ -81,11 +81,7 @@ async def test_deploy_charms(ops_test: OpsTest):
         ),
     )
 
-    if app_name:
-        APP_NAMES.append(app_name)
-    else:
-        APP_NAMES.append(DATABASE_APP_NAME)
-
+APP_NAMES.append(await get_app_name(ops_test, test_deployments=[ANOTHER_DATABASE_APP_NAME]))
     await ops_test.model.wait_for_idle(apps=APP_NAMES, status="active", timeout=1000)
 
 

--- a/tests/integration/relation_tests/test_charm_relations.py
+++ b/tests/integration/relation_tests/test_charm_relations.py
@@ -146,10 +146,8 @@ async def verify_crud_operations(ops_test: OpsTest, connection_string: str):
 async def test_database_relation_with_charm_libraries(ops_test: OpsTest):
     """Test basic functionality of database relation interface."""
     # Relate the charms and wait for them exchanging some connection data.
-    db_app_name = (
-        await get_app_name(ops_test, test_deployments=[ANOTHER_DATABASE_APP_NAME])
-        or DATABASE_APP_NAME
-    )
+    db_app_name = await get_app_name(ops_test, test_deployments=[ANOTHER_DATABASE_APP_NAME])
+
     await ops_test.model.integrate(
         f"{APPLICATION_APP_NAME}:{FIRST_DATABASE_RELATION_NAME}", db_app_name
     )
@@ -181,10 +179,8 @@ async def verify_primary(ops_test: OpsTest, application_name: str):
 async def test_app_relation_metadata_change(ops_test: OpsTest) -> None:
     """Verifies that the app metadata changes with db relation joined and departed events."""
     # verify application metadata is correct before adding/removing units.
-    db_app_name = (
-        await get_app_name(ops_test, test_deployments=[ANOTHER_DATABASE_APP_NAME])
-        or DATABASE_APP_NAME
-    )
+    db_app_name = await get_app_name(ops_test, test_deployments=[ANOTHER_DATABASE_APP_NAME])
+
     try:
         await verify_application_data(
             ops_test, APPLICATION_APP_NAME, db_app_name, FIRST_DATABASE_RELATION_NAME
@@ -334,10 +330,8 @@ async def test_two_applications_doesnt_share_the_same_relation_data(ops_test: Op
     )
     await ops_test.model.wait_for_idle(apps=all_app_names, status="active")
 
-    db_app_name = (
-        await get_app_name(ops_test, test_deployments=[ANOTHER_DATABASE_APP_NAME])
-        or DATABASE_APP_NAME
-    )
+    db_app_name = await get_app_name(ops_test, test_deployments=[ANOTHER_DATABASE_APP_NAME])
+
     # Relate the new application with the database
     # and wait for them exchanging some connection data.
     await ops_test.model.integrate(
@@ -359,10 +353,8 @@ async def test_an_application_can_connect_to_multiple_database_clusters(ops_test
     """Test that an application can connect to different clusters of the same database."""
     # Relate the application with both database clusters
     # and wait for them exchanging some connection data.
-    db_app_name = (
-        await get_app_name(ops_test, test_deployments=[ANOTHER_DATABASE_APP_NAME])
-        or DATABASE_APP_NAME
-    )
+    db_app_name = await get_app_name(ops_test, test_deployments=[ANOTHER_DATABASE_APP_NAME])
+
     first_cluster_relation = await ops_test.model.integrate(
         f"{APPLICATION_APP_NAME}:{MULTIPLE_DATABASE_CLUSTERS_RELATION_NAME}", db_app_name
     )
@@ -395,10 +387,7 @@ async def test_an_application_can_connect_to_multiple_aliased_database_clusters(
     """Test that an application can connect to different clusters of the same database."""
     # Relate the application with both database clusters
     # and wait for them exchanging some connection data.
-    db_app_name = (
-        await get_app_name(ops_test, test_deployments=[ANOTHER_DATABASE_APP_NAME])
-        or DATABASE_APP_NAME
-    )
+    db_app_name = await get_app_name(ops_test, test_deployments=[ANOTHER_DATABASE_APP_NAME])
     await asyncio.gather(
         ops_test.model.integrate(
             f"{APPLICATION_APP_NAME}:{ALIASED_MULTIPLE_DATABASE_CLUSTERS_RELATION_NAME}",
@@ -434,10 +423,8 @@ async def test_an_application_can_connect_to_multiple_aliased_database_clusters(
 async def test_an_application_can_request_multiple_databases(ops_test: OpsTest):
     """Test that an application can request additional databases using the same interface."""
     # Relate the charms using another relation and wait for them exchanging some connection data.
-    db_app_name = (
-        await get_app_name(ops_test, test_deployments=[ANOTHER_DATABASE_APP_NAME])
-        or DATABASE_APP_NAME
-    )
+    db_app_name = await get_app_name(ops_test, test_deployments=[ANOTHER_DATABASE_APP_NAME])
+
     await ops_test.model.integrate(
         f"{APPLICATION_APP_NAME}:{SECOND_DATABASE_RELATION_NAME}", db_app_name
     )
@@ -461,10 +448,8 @@ async def test_removed_relation_no_longer_has_access(ops_test: OpsTest):
     connection_string = await get_connection_string(
         ops_test, APPLICATION_APP_NAME, FIRST_DATABASE_RELATION_NAME
     )
-    db_app_name = (
-        await get_app_name(ops_test, test_deployments=[ANOTHER_DATABASE_APP_NAME])
-        or DATABASE_APP_NAME
-    )
+    db_app_name = await get_app_name(ops_test, test_deployments=[ANOTHER_DATABASE_APP_NAME])
+
     await ops_test.model.applications[db_app_name].remove_relation(
         f"{APPLICATION_APP_NAME}:{FIRST_DATABASE_RELATION_NAME}", f"{db_app_name}:database"
     )

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -3,7 +3,6 @@
 # See LICENSE file for licensing details.
 
 import logging
-import os
 import time
 from uuid import uuid4
 
@@ -37,10 +36,6 @@ from .helpers import (
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.skipif(
-    os.environ.get("PYTEST_SKIP_DEPLOY", False),
-    reason="skipping deploy, model expected to be provided.",
-)
 @pytest.mark.abort_on_fail
 async def test_build_and_deploy(ops_test: OpsTest):
     """Build the charm-under-test and deploy it together with related charms.

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -152,7 +152,7 @@ async def test_only_leader_can_set_while_all_can_read_password_secret(ops_test: 
         password=new_password,
         app_name=app_name,
     )
-    # get password after attemtp to set it up with non-leader
+    # get password after attempt to set it up with non-leader
     password1 = await get_password(
         ops_test, unit_id=leader_id, username="monitor", app_name=app_name
     )
@@ -218,7 +218,7 @@ async def test_empty_password(ops_test: OpsTest) -> None:
     """Test that the password can't be set to an empty string."""
     app_name = await get_app_name(ops_test)
     leader_id = await get_leader_id(ops_test, app_name=app_name)
-    
+
     password1 = await get_password(
         ops_test, unit_id=leader_id, username="monitor", app_name=app_name
     )

--- a/tests/integration/test_teardown.py
+++ b/tests/integration/test_teardown.py
@@ -3,7 +3,6 @@
 # See LICENSE file for licensing details.
 
 import logging
-import os
 
 import pytest
 from pytest_operator.plugin import OpsTest
@@ -17,10 +16,6 @@ MEDIAN_REELECTION_TIME = 12
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.skipif(
-    os.environ.get("PYTEST_SKIP_DEPLOY", False),
-    reason="skipping deploy, model expected to be provided.",
-)
 @pytest.mark.abort_on_fail
 async def test_build_and_deploy(ops_test: OpsTest):
     """Build the charm-under-test and deploy it to the model.
@@ -75,7 +70,7 @@ async def scale_and_verify(ops_test: OpsTest, count: int):
     else:
         logger.info(f"Scaling down by {abs(count)} units")
 
-    app_name = await get_app_name(ops_test) or DATABASE_APP_NAME
+    app_name = await get_app_name(ops_test)
     await ops_test.model.applications[app_name].scale(scale_change=count)
 
     await ops_test.model.wait_for_idle(

--- a/tests/integration/tls_tests/test_tls.py
+++ b/tests/integration/tls_tests/test_tls.py
@@ -129,7 +129,7 @@ async def test_build_and_deploy(ops_test: OpsTest) -> None:
 async def test_enable_tls(ops_test: OpsTest) -> None:
     """Verify each unit has TLS enabled after relating to the TLS application."""
     # Relate it to the MongoDB to enable TLS.
-    app_name = await get_app_name(ops_test) or DATABASE_APP_NAME
+    app_name = await get_app_name(ops_test)
     # check if relation exists
     await ops_test.model.relate(app_name, TLS_CERTIFICATES_APP_NAME)
 
@@ -146,7 +146,7 @@ async def test_rotate_tls_key(ops_test: OpsTest) -> None:
 
     This test rotates tls private keys to randomly generated keys.
     """
-    app_name = await get_app_name(ops_test) or DATABASE_APP_NAME
+    app_name = await get_app_name(ops_test)
     # dict of values for cert file certion and mongod service start times. After resetting the
     # private keys these certificates should be updated and the mongod service should be
     # restarted
@@ -208,7 +208,7 @@ async def test_set_tls_key(ops_test: OpsTest) -> None:
 
     This test rotates tls private keys to user specified keys.
     """
-    app_name = await get_app_name(ops_test) or DATABASE_APP_NAME
+    app_name = await get_app_name(ops_test)
     # dict of values for cert file certion and mongod service start times. After resetting the
     # private keys these certificates should be updated and the mongod service should be
     # restarted
@@ -284,7 +284,7 @@ async def test_set_tls_key(ops_test: OpsTest) -> None:
 
 async def test_disable_tls(ops_test: OpsTest) -> None:
     """Verify each unit has TLS disabled after removing relation to the TLS application."""
-    app_name = await get_app_name(ops_test) or DATABASE_APP_NAME
+    app_name = await get_app_name(ops_test)
     # Remove the relation.
     await ops_test.model.applications[app_name].remove_relation(
         f"{app_name}:certificates", f"{TLS_CERTIFICATES_APP_NAME}:certificates"

--- a/tests/integration/tls_tests/test_tls.py
+++ b/tests/integration/tls_tests/test_tls.py
@@ -3,7 +3,6 @@
 # See LICENSE file for licensing details.
 import json
 import logging
-import os
 import time
 
 import pytest

--- a/tests/integration/tls_tests/test_tls.py
+++ b/tests/integration/tls_tests/test_tls.py
@@ -2,13 +2,21 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 import json
+import logging
+import os
 import time
 
 import pytest
 from ops import Unit
 from pytest_operator.plugin import OpsTest
 
-from ..helpers import get_application_relation_data, get_secret_content, get_secret_id
+from ..helpers import (
+    check_or_scale_app,
+    get_app_name,
+    get_application_relation_data,
+    get_secret_content,
+    get_secret_id,
+)
 from .helpers import (
     METADATA,
     check_tls,
@@ -24,6 +32,8 @@ TLS_TEST_DATA = "tests/integration/tls_tests/data"
 EXTERNAL_CERT_PATH = "/etc/mongod/external-ca.crt"
 INTERNAL_CERT_PATH = "/etc/mongod/internal-ca.crt"
 DB_SERVICE = "mongod.service"
+
+logger = logging.getLogger(__name__)
 
 
 async def check_certs_correctly_distributed(ops_test: OpsTest, unit: Unit) -> None:
@@ -78,33 +88,56 @@ async def check_certs_correctly_distributed(ops_test: OpsTest, unit: Unit) -> No
         assert relation_internal_cert == internal_contents_file
 
 
+@pytest.mark.skipif(
+    os.environ.get("PYTEST_SKIP_DEPLOY", False),
+    reason="skipping deploy, model expected to be provided.",
+)
 @pytest.mark.abort_on_fail
 async def test_build_and_deploy(ops_test: OpsTest) -> None:
     """Build and deploy three units of MongoDB and one unit of TLS."""
-    async with ops_test.fast_forward():
-        my_charm = await ops_test.build_charm(".")
-        resources = {"mongodb-image": METADATA["resources"]["mongodb-image"]["upstream-source"]}
-        await ops_test.model.deploy(my_charm, num_units=1, resources=resources, series="jammy")
-        await ops_test.model.wait_for_idle(apps=[DATABASE_APP_NAME], status="active", timeout=2000)
+    app_name = await get_app_name(ops_test)
+    if app_name:
+        await check_or_scale_app(ops_test, app_name, 1)
+    else:
+        app_name = DATABASE_APP_NAME
+        async with ops_test.fast_forward():
+            my_charm = await ops_test.build_charm(".")
+            resources = {
+                "mongodb-image": METADATA["resources"]["mongodb-image"]["upstream-source"]
+            }
+            await ops_test.model.deploy(my_charm, num_units=1, resources=resources, series="jammy")
+            await ops_test.model.wait_for_idle(apps=[app_name], status="active", timeout=2000)
 
-        config = {"generate-self-signed-certificates": "true", "ca-common-name": "Test CA"}
-        await ops_test.model.deploy(
-            TLS_CERTIFICATES_APP_NAME, channel="stable", config=config, series="jammy"
-        )
-        await ops_test.model.wait_for_idle(
-            apps=[TLS_CERTIFICATES_APP_NAME], status="active", timeout=1000
-        )
+    tls_app_deployed = False
+    status = await ops_test.model.get_status()
+    for app in ops_test.model.applications:
+        if TLS_CERTIFICATES_APP_NAME in status["applications"][app]["charm"]:
+            logger.debug("Found TLS app name app named '%s'", app)
+            tls_app_deployed = True
+
+    if not tls_app_deployed:
+        async with ops_test.fast_forward():
+            config = {"generate-self-signed-certificates": "true", "ca-common-name": "Test CA"}
+            await ops_test.model.deploy(
+                TLS_CERTIFICATES_APP_NAME, channel="stable", config=config, series="jammy"
+            )
+            await ops_test.model.wait_for_idle(
+                apps=[TLS_CERTIFICATES_APP_NAME], status="active", timeout=1000
+            )
 
 
 async def test_enable_tls(ops_test: OpsTest) -> None:
     """Verify each unit has TLS enabled after relating to the TLS application."""
     # Relate it to the MongoDB to enable TLS.
-    await ops_test.model.relate(DATABASE_APP_NAME, TLS_CERTIFICATES_APP_NAME)
+    app_name = await get_app_name(ops_test) or DATABASE_APP_NAME
+    # check if relation exists
+    await ops_test.model.relate(app_name, TLS_CERTIFICATES_APP_NAME)
+
     async with ops_test.fast_forward():
         await ops_test.model.wait_for_idle(status="active", timeout=1000)
 
     # Wait for all units enabling TLS.
-    for unit in ops_test.model.applications[DATABASE_APP_NAME].units:
+    for unit in ops_test.model.applications[app_name].units:
         assert await check_tls(ops_test, unit, enabled=True)
 
 
@@ -113,11 +146,12 @@ async def test_rotate_tls_key(ops_test: OpsTest) -> None:
 
     This test rotates tls private keys to randomly generated keys.
     """
+    app_name = await get_app_name(ops_test) or DATABASE_APP_NAME
     # dict of values for cert file certion and mongod service start times. After resetting the
     # private keys these certificates should be updated and the mongod service should be
     # restarted
     original_tls_times = {}
-    for unit in ops_test.model.applications[DATABASE_APP_NAME].units:
+    for unit in ops_test.model.applications[app_name].units:
         original_tls_times[unit.name] = {}
         original_tls_times[unit.name]["external_cert"] = await time_file_created(
             ops_test, unit.name, EXTERNAL_CERT_PATH
@@ -131,7 +165,7 @@ async def test_rotate_tls_key(ops_test: OpsTest) -> None:
         check_certs_correctly_distributed(ops_test, unit)
 
     # set external and internal key using auto-generated key for each unit
-    for unit in ops_test.model.applications[DATABASE_APP_NAME].units:
+    for unit in ops_test.model.applications[app_name].units:
         action = await unit.run_action(action_name="set-tls-private-key")
         action = await action.wait()
         assert action.status == "completed", "setting external and internal key failed."
@@ -142,7 +176,7 @@ async def test_rotate_tls_key(ops_test: OpsTest) -> None:
 
     # After updating both the external key and the internal key a new certificate request will be
     # made; then the certificates should be available and updated.
-    for unit in ops_test.model.applications[DATABASE_APP_NAME].units:
+    for unit in ops_test.model.applications[app_name].units:
         new_external_cert_time = await time_file_created(ops_test, unit.name, EXTERNAL_CERT_PATH)
         new_internal_cert_time = await time_file_created(ops_test, unit.name, INTERNAL_CERT_PATH)
         new_mongod_service_time = await time_process_started(ops_test, unit.name, DB_SERVICE)
@@ -163,7 +197,7 @@ async def test_rotate_tls_key(ops_test: OpsTest) -> None:
         ), f"mongod service for {unit.name} was not restarted."
 
     # Verify that TLS is functioning on all units.
-    for unit in ops_test.model.applications[DATABASE_APP_NAME].units:
+    for unit in ops_test.model.applications[app_name].units:
         assert await check_tls(
             ops_test, unit, enabled=True
         ), f"tls is not enabled for {unit.name}."
@@ -174,11 +208,12 @@ async def test_set_tls_key(ops_test: OpsTest) -> None:
 
     This test rotates tls private keys to user specified keys.
     """
+    app_name = await get_app_name(ops_test) or DATABASE_APP_NAME
     # dict of values for cert file certion and mongod service start times. After resetting the
     # private keys these certificates should be updated and the mongod service should be
     # restarted
     original_tls_times = {}
-    for unit in ops_test.model.applications[DATABASE_APP_NAME].units:
+    for unit in ops_test.model.applications[app_name].units:
         original_tls_times[unit.name] = {}
         original_tls_times[unit.name]["external_cert"] = await time_file_created(
             ops_test, unit.name, EXTERNAL_CERT_PATH
@@ -195,8 +230,8 @@ async def test_set_tls_key(ops_test: OpsTest) -> None:
         internal_key_contents = "".join(internal_key_contents)
 
     # set external and internal key for each unit
-    for unit_id in range(len(ops_test.model.applications[DATABASE_APP_NAME].units)):
-        unit = ops_test.model.applications[DATABASE_APP_NAME].units[unit_id]
+    for unit_id in range(len(ops_test.model.applications[app_name].units)):
+        unit = ops_test.model.applications[app_name].units[unit_id]
 
         with open(f"{TLS_TEST_DATA}/external-key-{unit_id}.pem") as f:
             external_key_contents = f.readlines()
@@ -220,7 +255,7 @@ async def test_set_tls_key(ops_test: OpsTest) -> None:
 
     # After updating both the external key and the internal key a new certificate request will be
     # made; then the certificates should be available and updated.
-    for unit in ops_test.model.applications[DATABASE_APP_NAME].units:
+    for unit in ops_test.model.applications[app_name].units:
         new_external_cert_time = await time_file_created(ops_test, unit.name, EXTERNAL_CERT_PATH)
         new_internal_cert_time = await time_file_created(ops_test, unit.name, INTERNAL_CERT_PATH)
         new_mongod_service_time = await time_process_started(ops_test, unit.name, DB_SERVICE)
@@ -241,7 +276,7 @@ async def test_set_tls_key(ops_test: OpsTest) -> None:
         ), f"mongod service for {unit.name} was not restarted."
 
     # Verify that TLS is functioning on all units.
-    for unit in ops_test.model.applications[DATABASE_APP_NAME].units:
+    for unit in ops_test.model.applications[app_name].units:
         assert await check_tls(
             ops_test, unit, enabled=True
         ), f"tls is not enabled for {unit.name}."
@@ -249,13 +284,14 @@ async def test_set_tls_key(ops_test: OpsTest) -> None:
 
 async def test_disable_tls(ops_test: OpsTest) -> None:
     """Verify each unit has TLS disabled after removing relation to the TLS application."""
+    app_name = await get_app_name(ops_test) or DATABASE_APP_NAME
     # Remove the relation.
-    await ops_test.model.applications[DATABASE_APP_NAME].remove_relation(
-        f"{DATABASE_APP_NAME}:certificates", f"{TLS_CERTIFICATES_APP_NAME}:certificates"
+    await ops_test.model.applications[app_name].remove_relation(
+        f"{app_name}:certificates", f"{TLS_CERTIFICATES_APP_NAME}:certificates"
     )
     async with ops_test.fast_forward():
-        await ops_test.model.wait_for_idle(apps=[DATABASE_APP_NAME], status="active", timeout=1000)
+        await ops_test.model.wait_for_idle(apps=[app_name], status="active", timeout=1000)
 
     # Wait for all units disabling TLS.
-    for unit in ops_test.model.applications[DATABASE_APP_NAME].units:
+    for unit in ops_test.model.applications[app_name].units:
         assert await check_tls(ops_test, unit, enabled=False)

--- a/tests/integration/tls_tests/test_tls.py
+++ b/tests/integration/tls_tests/test_tls.py
@@ -88,10 +88,6 @@ async def check_certs_correctly_distributed(ops_test: OpsTest, unit: Unit) -> No
         assert relation_internal_cert == internal_contents_file
 
 
-@pytest.mark.skipif(
-    os.environ.get("PYTEST_SKIP_DEPLOY", False),
-    reason="skipping deploy, model expected to be provided.",
-)
 @pytest.mark.abort_on_fail
 async def test_build_and_deploy(ops_test: OpsTest) -> None:
     """Build and deploy three units of MongoDB and one unit of TLS."""

--- a/tox.ini
+++ b/tox.ini
@@ -59,7 +59,7 @@ commands =
         -m pytest -v --tb native -s {posargs} {[vars]tests_path}/unit
     poetry run coverage report
 
-[testenv:integration]
+[testenv:charm-integration]
 description = Run integration tests
 set_env =
     {[testenv]set_env}


### PR DESCRIPTION
## About
The goal of this PR is to allow users to run integration tests on existing cluster

Note: At the moment backup tests are disabled on CI. 
There is [a ticket for to investigate backup](https://warthogs.atlassian.net/browse/DPE-4217) \ backup tests failure and then the tests [needs to be enabled](https://warthogs.atlassian.net/browse/DPE-4216).
There is also a[ ticket for flickering HA test `test_storage_re_use`](https://warthogs.atlassian.net/browse/DPE-4215)

The rest of the tests are passing on existing cluster and without providing a cluster.

[Proof of runs on a provided cluster](https://chat.canonical.com/canonical/pl/8kjbdq3ndjg6fb7b7ffpdbshsy)