### PR TITLE
move user init code out of repl set init code

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,7 +30,7 @@ jobs:
   unit-test:
     name: Unit tests
     runs-on: ubuntu-latest
-    timeout-minutes: 15 # TODO: reduce to 5 minutes
+    timeout-minutes: 25 # TODO: reduce to 5 minutes
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/lib/charms/mongodb/v0/mongodb.py
+++ b/lib/charms/mongodb/v0/mongodb.py
@@ -145,6 +145,7 @@ class MongoDBConnection:
         try:
             for attempt in Retrying(stop=stop_after_delay(60), wait=wait_fixed(3)):
                 with attempt:
+                    print("ATTEMPT")
                     # The ping command is cheap and does not require auth.
                     self.client.admin.command("ping")
         except RetryError:

--- a/lib/charms/mongodb/v0/mongodb.py
+++ b/lib/charms/mongodb/v0/mongodb.py
@@ -145,7 +145,6 @@ class MongoDBConnection:
         try:
             for attempt in Retrying(stop=stop_after_delay(60), wait=wait_fixed(3)):
                 with attempt:
-                    print("ATTEMPT")
                     # The ping command is cheap and does not require auth.
                     self.client.admin.command("ping")
         except RetryError:

--- a/src/charm.py
+++ b/src/charm.py
@@ -287,7 +287,7 @@ class MongoDBCharm(CharmBase):
         """Check if the MongoDB replica set is initialised."""
         return "replica_set_initialised" in self.app_peer_data
 
-    @db_initialised.setter
+    @replica_set_initialised.setter
     def replica_set_initialised(self, value):
         """Set the replica_set_initialised flag."""
         if isinstance(value, bool):

--- a/src/charm.py
+++ b/src/charm.py
@@ -682,8 +682,6 @@ class MongoDBCharm(CharmBase):
             event.defer()
             raise  # we need to raise to make retry work
 
-        self.replica_set_initialised = True
-
     @retry(
         stop=stop_after_attempt(3),
         wait=wait_fixed(5),
@@ -876,6 +874,8 @@ class MongoDBCharm(CharmBase):
                 logger.error("Deferring on_start since: error=%r", e)
                 event.defer()
                 return
+
+        self.replica_set_initialised = True
 
     def _add_units_from_replica_set(
         self, event, mongo: MongoDBConnection, units_to_add: Set[str]

--- a/src/charm.py
+++ b/src/charm.py
@@ -436,12 +436,11 @@ class MongoDBCharm(CharmBase):
         self._initialise_replica_set(event)
         try:
             self._initialise_users(event)
+            self.db_initialised = True
         except RetryError:
             logger.error("Failed to initialise users. Deferring start event.")
             event.defer()
             return
-
-        self.db_initialised = True
 
     def _relation_changes_handler(self, event) -> None:
         """Handles different relation events and updates MongoDB replica set."""

--- a/src/charm.py
+++ b/src/charm.py
@@ -656,13 +656,6 @@ class MongoDBCharm(CharmBase):
         In race conditions this can lead to failure to initialise users.
         To prevent these race conditions from breaking the code, retry on failure.
         """
-        if not self.replica_set_initialised:
-            logger.error(
-                "Deferring on_start: Failed to create operator user, since replica set is not initialised."
-            )
-            event.defer()
-            return
-
         if self.users_initialized:
             return
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -297,7 +297,7 @@ class TestCharm(unittest.TestCase):
         mock_container.return_value.exists.return_value = True
         self.harness.charm.unit.get_container = mock_container
 
-        self.harness.charm.app_peer_data["db_initialised"] = "True"
+        self.harness.charm.app_peer_data["replica_set_initialised"] = "True"
         self.harness.charm.app_peer_data["users_initialized"] = "True"
 
         self.harness.charm.on.start.emit()
@@ -369,7 +369,7 @@ class TestCharm(unittest.TestCase):
             provider.return_value.oversee_users.assert_not_called()
 
             # verify app data
-            self.assertEqual("db_initialised" in self.harness.charm.app_peer_data, False)
+            self.assertEqual("replica_set_initialised" in self.harness.charm.app_peer_data, False)
             defer.assert_called()
 
     @patch("ops.framework.EventBase.defer")
@@ -399,7 +399,7 @@ class TestCharm(unittest.TestCase):
         defer.assert_called()
 
         # verify app data
-        self.assertEqual("db_initialised" in self.harness.charm.app_peer_data, False)
+        self.assertEqual("replica_set_initialised" in self.harness.charm.app_peer_data, False)
 
     @patch("ops.framework.EventBase.defer")
     @patch("charm.MongoDBProvider")
@@ -432,7 +432,7 @@ class TestCharm(unittest.TestCase):
             defer.assert_called()
 
             # verify app data
-            self.assertEqual("db_initialised" in self.harness.charm.app_peer_data, False)
+            self.assertEqual("replica_set_initialised" in self.harness.charm.app_peer_data, False)
 
     @patch("ops.framework.EventBase.defer")
     @patch("charm.MongoDBConnection")
@@ -620,6 +620,7 @@ class TestCharm(unittest.TestCase):
 
         oversee_users.side_effect = PyMongoError()
 
+        self.harness.charm.app_peer_data["replica_set_initialised"] = "True"
         self.harness.charm.on.start.emit()
 
         # verify app data
@@ -935,6 +936,7 @@ class TestCharm(unittest.TestCase):
     ):
         """Tests what backup user was created."""
         container = self.harness.model.unit.get_container("mongod")
+        self.harness.charm.app_peer_data["replica_set_initialised"] = "True"
         self.harness.set_can_connect(container, True)
         self.harness.charm.on.start.emit()
         password = self.harness.charm.get_secret("app", "backup-password")

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -18,6 +18,7 @@ from pymongo.errors import (
     OperationFailure,
     PyMongoError,
 )
+from tenacity import stop_after_attempt, wait_fixed, wait_none
 
 from charm import MongoDBCharm, NotReadyError
 
@@ -342,10 +343,10 @@ class TestCharm(unittest.TestCase):
 
     @patch("ops.framework.EventBase.defer")
     @patch("charm.MongoDBProvider")
-    @patch("charm.MongoDBCharm._init_operator_user")
+    @patch("charm.MongoDBCharm._initialise_users")
     @patch("charm.MongoDBConnection")
     def test_start_mongod_error_initalising_replica_set(
-        self, connection, init_user, provider, defer
+        self, connection, init_users, provider, defer
     ):
         """Tests that failure to initialise replica set is properly handled.
 
@@ -361,12 +362,12 @@ class TestCharm(unittest.TestCase):
         self.harness.charm.unit.get_container = mock_container
         connection.return_value.__enter__.return_value.is_ready = True
 
-        for exception, expected_raise in PYMONGO_EXCEPTIONS:
+        for exception, _ in PYMONGO_EXCEPTIONS:
             connection.return_value.__enter__.return_value.init_replset.side_effect = exception
             self.harness.charm.on.start.emit()
 
             # verify app data
-            self.assertEqual("db_initialised" in self.harness.charm.app_peer_data, False)
+            self.assertEqual("replica_set_initialised" in self.harness.charm.app_peer_data, False)
             defer.assert_called()
 
     @patch("ops.framework.EventBase.defer")
@@ -374,7 +375,7 @@ class TestCharm(unittest.TestCase):
     @patch("charm.MongoDBCharm._init_operator_user")
     @patch("charm.MongoDBConnection")
     @patch("tenacity.nap.time.sleep", MagicMock())
-    def test_start_mongod_error_initalising_user(self, connection, init_user, provider, defer):
+    def test_error_initalising_users(self, connection, init_user, provider, defer):
         """Tests that failure to initialise users set is properly handled.
 
         Verifies that when there is a failure to initialise users that overseeing users is not
@@ -390,13 +391,14 @@ class TestCharm(unittest.TestCase):
         connection.return_value.__enter__.return_value.is_ready = True
 
         init_user.side_effect = ExecError("command", 0, "stdout", "stderr")
+        self.harness.charm._initialise_users.retry.wait = wait_none()
         self.harness.charm.on.start.emit()
 
         provider.return_value.oversee_users.assert_not_called()
         defer.assert_called()
 
         # verify app data
-        self.assertEqual("replica_set_initialised" in self.harness.charm.app_peer_data, False)
+        self.assertEqual("db_initialised" in self.harness.charm.app_peer_data, False)
 
     @patch("ops.framework.EventBase.defer")
     @patch("charm.MongoDBProvider")
@@ -406,7 +408,11 @@ class TestCharm(unittest.TestCase):
     @patch("charm.USER_CREATING_MAX_ATTEMPTS", 1)
     @patch("charm.USER_CREATION_COOLDOWN", 1)
     @patch("charm.REPLICA_SET_INIT_CHECK_TIMEOUT", 1)
-    def test_start_mongod_error_overseeing_users(self, connection, init_user, provider, defer):
+    @patch("charm.wait_fixed")
+    @patch("charm.stop_after_attempt")
+    def test_start_mongod_error_overseeing_users(
+        self, retry_stop, retry_wait, connection, init_user, provider, defer
+    ):
         """Tests failures related to pymongo are properly handled when overseeing users.
 
         Verifies that when there is a failure to oversee users that we defer and do not set the
@@ -420,8 +426,11 @@ class TestCharm(unittest.TestCase):
         mock_container.return_value.exists.return_value = True
         self.harness.charm.unit.get_container = mock_container
         connection.return_value.__enter__.return_value.is_ready = True
+        retry_stop.return_value = stop_after_attempt(1)
+        retry_wait.return_value = wait_fixed(1)
+        self.harness.charm._initialise_users.retry.wait = wait_none()
 
-        for exception, expected_raise in PYMONGO_EXCEPTIONS:
+        for exception, _ in PYMONGO_EXCEPTIONS:
             provider.side_effect = exception
             self.harness.charm.on.start.emit()
 
@@ -429,7 +438,7 @@ class TestCharm(unittest.TestCase):
             defer.assert_called()
 
             # verify app data
-            self.assertEqual("replica_set_initialised" in self.harness.charm.app_peer_data, False)
+            self.assertEqual("db_initialised" in self.harness.charm.app_peer_data, False)
 
     @patch("ops.framework.EventBase.defer")
     @patch("charm.MongoDBConnection")
@@ -605,6 +614,10 @@ class TestCharm(unittest.TestCase):
         Verifies that if the user is already set up, that no attempts to set it up again are
         made when a failure happens causing an event deferring calling the init_user again
         """
+        self.harness.charm.USER_CREATING_MAX_ATTEMPTS = 1
+        self.harness.charm.USER_CREATION_COOLDOWN = 1
+        self.harness.charm._initialise_users.retry.wait = wait_none()
+
         mock_container = mock.Mock()
         mock_container.return_value.can_connect.return_value = True
         mock_container.return_value.exists.return_value = True
@@ -619,8 +632,6 @@ class TestCharm(unittest.TestCase):
 
         self.harness.charm.app_peer_data["replica_set_initialised"] = "True"
         self.harness.charm.on.start.emit()
-
-        # verify app data
         self.assertEqual("operator-user-created" in self.harness.charm.app_peer_data, True)
         defer.assert_called()
 
@@ -932,11 +943,13 @@ class TestCharm(unittest.TestCase):
         _init_monitor_user,
     ):
         """Tests what backup user was created."""
+        self.harness.charm._initialise_users.retry.wait = wait_none()
         container = self.harness.model.unit.get_container("mongod")
         self.harness.charm.app_peer_data["replica_set_initialised"] = "True"
         self.harness.set_can_connect(container, True)
         self.harness.charm.on.start.emit()
         password = self.harness.charm.get_secret("app", "backup-password")
+        self.harness.charm._initialise_users.retry.wait = wait_none()
         self.assertIsNotNone(password)  # verify the password is set
 
     @patch("charm.MongoDBConnection")

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -349,8 +349,8 @@ class TestCharm(unittest.TestCase):
     ):
         """Tests that failure to initialise replica set is properly handled.
 
-        Verifies that when there is a failure to initialise replica set that no operations related
-        to setting up users are executed.
+        Verifies that when there is a failure to initialise replica set the defer is called and
+        db_initialised is not set to initialised.
         """
         # presets
         self.harness.set_leader(True)
@@ -365,11 +365,8 @@ class TestCharm(unittest.TestCase):
             connection.return_value.__enter__.return_value.init_replset.side_effect = exception
             self.harness.charm.on.start.emit()
 
-            init_user.assert_not_called()
-            provider.return_value.oversee_users.assert_not_called()
-
             # verify app data
-            self.assertEqual("replica_set_initialised" in self.harness.charm.app_peer_data, False)
+            self.assertEqual("db_initialised" in self.harness.charm.app_peer_data, False)
             defer.assert_called()
 
     @patch("ops.framework.EventBase.defer")


### PR DESCRIPTION
## Issue
CI tests are failing to create users 

On further inspection [of the debug log in this workflow](https://github.com/canonical/mongodb-k8s-operator/actions/runs/8797992063/job/24145056569?pr=243), in the function `_initialise_replica_set`, there are still calls to initialise users.

## Solution
remove any calls to initialise users in `_initialise_replica_set`

## Other
Also the fact that `_initialise_replica_set` sets `db_initialised` to true is problematic. Because if the `_initialise_users` functions fails, then another hooks will check whether `db_initialised` is true and proceed to fail since the user they will try to access the DB with won't have been created yet