### PR TITLE
[DPE-4858] Upgrade TLS lib and add status lib

### DIFF
--- a/lib/charms/mongodb/v0/mongodb_tls.py
+++ b/lib/charms/mongodb/v0/mongodb_tls.py
@@ -22,11 +22,10 @@ from charms.tls_certificates_interface.v3.tls_certificates import (
 )
 from ops.charm import ActionEvent, RelationBrokenEvent, RelationJoinedEvent
 from ops.framework import Object
-from ops.model import ActiveStatus, MaintenanceStatus, Unit
+from ops.model import ActiveStatus, MaintenanceStatus, Unit, WaitingStatus
 
 from config import Config
 
-APP_SCOPE = Config.Relations.APP_SCOPE
 UNIT_SCOPE = Config.Relations.UNIT_SCOPE
 Scopes = Config.Relations.Scopes
 
@@ -39,7 +38,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 6
+LIBPATCH = 15
 
 logger = logging.getLogger(__name__)
 
@@ -68,28 +67,38 @@ class MongoDBTLS(Object):
         self.framework.observe(self.certs.on.certificate_available, self._on_certificate_available)
         self.framework.observe(self.certs.on.certificate_expiring, self._on_certificate_expiring)
 
-    def is_tls_enabled(self, scope: Scopes):
-        """Returns a boolean indicating if TLS for a given `scope` is enabled."""
-        return self.charm.get_secret(scope, Config.TLS.SECRET_CERT_LABEL) is not None
+    def is_tls_enabled(self, internal: bool):
+        """Returns a boolean indicating if TLS for a given internal/external is enabled."""
+        return self.get_tls_secret(internal, Config.TLS.SECRET_CERT_LABEL) is not None
 
     def _on_set_tls_private_key(self, event: ActionEvent) -> None:
         """Set the TLS private key, which will be used for requesting the certificate."""
         logger.debug("Request to set TLS private key received.")
+        if self.charm.is_role(Config.Role.MONGOS) and not self.charm.has_config_server():
+            logger.error(
+                "mongos is not running (not integrated to config-server) deferring renewal of certificates."
+            )
+            event.fail("Mongos cannot set TLS keys until integrated to config-server.")
+            return
+
+        if self.charm.upgrade_in_progress:
+            logger.warning("Setting TLS key during an upgrade is not supported.")
+            event.fail("Setting TLS key during an upgrade is not supported.")
+            return
+
         try:
-            self._request_certificate(UNIT_SCOPE, event.params.get("external-key", None))
-
-            if not self.charm.unit.is_leader():
-                event.log(
-                    "Only juju leader unit can set private key for the internal certificate. Skipping."
-                )
-                return
-
-            self._request_certificate(APP_SCOPE, event.params.get("internal-key", None))
+            self.request_certificate(event.params.get("external-key", None), internal=False)
+            self.request_certificate(event.params.get("internal-key", None), internal=True)
             logger.debug("Successfully set TLS private key.")
         except ValueError as e:
             event.fail(str(e))
 
-    def _request_certificate(self, scope: Scopes, param: Optional[str]):
+    def request_certificate(
+        self,
+        param: Optional[str],
+        internal: bool,
+    ):
+        """Request TLS certificate."""
         if param is None:
             key = generate_private_key()
         else:
@@ -97,15 +106,18 @@ class MongoDBTLS(Object):
 
         csr = generate_csr(
             private_key=key,
-            subject=self.get_host(self.charm.unit),
-            organization=self.charm.app.name,
+            subject=self._get_subject_name(),
+            organization=self._get_subject_name(),
             sans=self._get_sans(),
             sans_ip=[str(self.charm.model.get_binding(self.peer_relation).network.bind_address)],
         )
+        self.set_tls_secret(internal, Config.TLS.SECRET_KEY_LABEL, key.decode("utf-8"))
+        self.set_tls_secret(internal, Config.TLS.SECRET_CSR_LABEL, csr.decode("utf-8"))
+        self.set_tls_secret(internal, Config.TLS.SECRET_CERT_LABEL, None)
 
-        self.charm.set_secret(scope, Config.TLS.SECRET_KEY_LABEL, key.decode("utf-8"))
-        self.charm.set_secret(scope, Config.TLS.SECRET_CSR_LABEL, csr.decode("utf-8"))
-        self.charm.set_secret(scope, Config.TLS.SECRET_CERT_LABEL, None)
+        label = "int" if internal else "ext"
+        self.charm.unit_peer_data[f"{label}_certs_subject"] = self._get_subject_name()
+        self.charm.unit_peer_data[f"{label}_certs_subject"] = self._get_subject_name()
 
         if self.charm.model.get_relation(Config.TLS.TLS_PEER_RELATION):
             self.certs.request_certificate_creation(certificate_signing_request=csr)
@@ -125,115 +137,150 @@ class MongoDBTLS(Object):
             )
         return base64.b64decode(raw_content)
 
-    def _on_tls_relation_joined(self, _: RelationJoinedEvent) -> None:
+    def _on_tls_relation_joined(self, event: RelationJoinedEvent) -> None:
         """Request certificate when TLS relation joined."""
-        if self.charm.unit.is_leader():
-            self._request_certificate(APP_SCOPE, None)
-
-        self._request_certificate(UNIT_SCOPE, None)
-
-    def _on_tls_relation_broken(self, event: RelationBrokenEvent) -> None:
-        """Disable TLS when TLS relation broken."""
-        logger.debug("Disabling external TLS for unit: %s", self.charm.unit.name)
-        self.charm.set_secret(UNIT_SCOPE, Config.TLS.SECRET_CA_LABEL, None)
-        self.charm.set_secret(UNIT_SCOPE, Config.TLS.SECRET_CERT_LABEL, None)
-        self.charm.set_secret(UNIT_SCOPE, Config.TLS.SECRET_CHAIN_LABEL, None)
-
-        if self.charm.unit.is_leader():
-            logger.debug("Disabling internal TLS")
-            self.charm.set_secret(APP_SCOPE, Config.TLS.SECRET_CA_LABEL, None)
-            self.charm.set_secret(APP_SCOPE, Config.TLS.SECRET_CERT_LABEL, None)
-            self.charm.set_secret(APP_SCOPE, Config.TLS.SECRET_CHAIN_LABEL, None)
-
-        if self.charm.get_secret(APP_SCOPE, Config.TLS.SECRET_CERT_LABEL):
-            logger.debug(
-                "Defer until the leader deletes the internal TLS certificate to avoid second restart."
+        if self.charm.is_role(Config.Role.MONGOS) and not self.charm.has_config_server():
+            logger.info(
+                "mongos is not running (not integrated to config-server) deferring renewal of certificates."
             )
             event.defer()
             return
 
+        if self.charm.upgrade_in_progress:
+            logger.warning(
+                "Enabling TLS is not supported during an upgrade. The charm may be in a broken, unrecoverable state."
+            )
+            event.defer()
+            return
+
+        self.request_certificate(None, internal=True)
+        self.request_certificate(None, internal=False)
+
+    def _on_tls_relation_broken(self, event: RelationBrokenEvent) -> None:
+        """Disable TLS when TLS relation broken."""
+        logger.debug("Disabling external and internal TLS for unit: %s", self.charm.unit.name)
+        if self.charm.upgrade_in_progress:
+            logger.warning(
+                "Disabling TLS is not supported during an upgrade. The charm may be in a broken, unrecoverable state."
+            )
+
+        for internal in [True, False]:
+            self.set_tls_secret(internal, Config.TLS.SECRET_CA_LABEL, None)
+            self.set_tls_secret(internal, Config.TLS.SECRET_CERT_LABEL, None)
+            self.set_tls_secret(internal, Config.TLS.SECRET_CHAIN_LABEL, None)
+
+        if self.charm.is_role(Config.Role.CONFIG_SERVER):
+            self.charm.cluster.update_ca_secret(new_ca=None)
+            self.charm.config_server.update_ca_secret(new_ca=None)
+
         logger.info("Restarting mongod with TLS disabled.")
-        self.charm.unit.status = MaintenanceStatus("disabling TLS")
+        self.charm.status.set_and_share_status(MaintenanceStatus("disabling TLS"))
         self.charm.delete_tls_certificate_from_workload()
-        self.charm.restart_mongod_service()
-        self.charm.unit.status = ActiveStatus()
+        self.charm.restart_charm_services()
+        self.charm.status.set_and_share_status(ActiveStatus())
 
     def _on_certificate_available(self, event: CertificateAvailableEvent) -> None:
         """Enable TLS when TLS certificate available."""
-        unit_csr = self.charm.get_secret(UNIT_SCOPE, Config.TLS.SECRET_CSR_LABEL)
-        app_csr = self.charm.get_secret(APP_SCOPE, Config.TLS.SECRET_CSR_LABEL)
+        if self.charm.is_role(Config.Role.MONGOS) and not self.charm.config_server_db:
+            logger.debug(
+                "mongos requires config-server in order to start, do not restart with TLS until integrated to config-server"
+            )
+            event.defer()
+            return
 
-        if unit_csr and event.certificate_signing_request.rstrip() == unit_csr.rstrip():
+        int_csr = self.get_tls_secret(internal=True, label_name=Config.TLS.SECRET_CSR_LABEL)
+        ext_csr = self.get_tls_secret(internal=False, label_name=Config.TLS.SECRET_CSR_LABEL)
+
+        if ext_csr and event.certificate_signing_request.rstrip() == ext_csr.rstrip():
             logger.debug("The external TLS certificate available.")
-            scope = UNIT_SCOPE  # external crs
-        elif app_csr and event.certificate_signing_request.rstrip() == app_csr.rstrip():
+            internal = False
+        elif int_csr and event.certificate_signing_request.rstrip() == int_csr.rstrip():
             logger.debug("The internal TLS certificate available.")
-            scope = APP_SCOPE  # internal crs
+            internal = True
         else:
             logger.error("An unknown certificate is available -- ignoring.")
             return
 
-        if scope == UNIT_SCOPE or (scope == APP_SCOPE and self.charm.unit.is_leader()):
-            self.charm.set_secret(
-                scope,
-                Config.TLS.SECRET_CHAIN_LABEL,
-                "\n".join(event.chain) if event.chain is not None else None,
-            )
-            self.charm.set_secret(scope, Config.TLS.SECRET_CERT_LABEL, event.certificate)
-            self.charm.set_secret(scope, Config.TLS.SECRET_CA_LABEL, event.ca)
+        self.set_tls_secret(
+            internal,
+            Config.TLS.SECRET_CHAIN_LABEL,
+            "\n".join(event.chain) if event.chain is not None else None,
+        )
+        self.set_tls_secret(internal, Config.TLS.SECRET_CERT_LABEL, event.certificate)
+        self.set_tls_secret(internal, Config.TLS.SECRET_CA_LABEL, event.ca)
 
-        self.charm.unit.status = MaintenanceStatus("enabling TLS")
-        if self._waiting_for_certs():
+        if self.charm.is_role(Config.Role.CONFIG_SERVER) and internal:
+            self.charm.cluster.update_ca_secret(new_ca=event.ca)
+            self.charm.config_server.update_ca_secret(new_ca=event.ca)
+
+        if self.waiting_for_certs():
             logger.debug(
-                "Return till both internal and external TLS certificates available to avoid second restart."
+                "Defer till both internal and external TLS certificates available to avoid second restart."
             )
+            event.defer()
             return
 
         logger.info("Restarting mongod with TLS enabled.")
 
         self.charm.delete_tls_certificate_from_workload()
         self.charm.push_tls_certificate_to_workload()
-        self.charm.restart_mongod_service()
-        self.charm.unit.status = ActiveStatus()
+        self.charm.status.set_and_share_status(MaintenanceStatus("enabling TLS"))
+        self.charm.restart_charm_services()
 
-    def _waiting_for_certs(self):
+        if not self.charm.is_db_service_ready():
+            self.charm.status.set_and_share_status(WaitingStatus("Waiting for MongoDB to start"))
+        elif self.charm.unit.status == WaitingStatus(
+            "Waiting for MongoDB to start"
+        ) or self.charm.unit.status == MaintenanceStatus("enabling TLS"):
+            # clear waiting status if db service is ready
+            self.charm.status.set_and_share_status(ActiveStatus())
+
+    def waiting_for_certs(self):
         """Returns a boolean indicating whether additional certs are needed."""
-        if not self.charm.get_secret(APP_SCOPE, Config.TLS.SECRET_CERT_LABEL):
-            logger.debug("Waiting for application certificate.")
+        if not self.get_tls_secret(internal=True, label_name=Config.TLS.SECRET_CERT_LABEL):
+            logger.debug("Waiting for internal certificate.")
             return True
-        if not self.charm.get_secret(UNIT_SCOPE, Config.TLS.SECRET_CERT_LABEL):
-            logger.debug("Waiting for application certificate.")
+        if not self.get_tls_secret(internal=False, label_name=Config.TLS.SECRET_CERT_LABEL):
+            logger.debug("Waiting for external certificate.")
             return True
 
         return False
 
     def _on_certificate_expiring(self, event: CertificateExpiringEvent) -> None:
         """Request the new certificate when old certificate is expiring."""
+        if self.charm.is_role(Config.Role.MONGOS) and not self.charm.has_config_server():
+            logger.info(
+                "mongos is not running (not integrated to config-server) deferring renewal of certificates."
+            )
+            event.defer()
+            return
+
         if (
             event.certificate.rstrip()
-            == self.charm.get_secret(UNIT_SCOPE, Config.TLS.SECRET_CERT_LABEL).rstrip()
+            == self.get_tls_secret(
+                internal=False, label_name=Config.TLS.SECRET_CERT_LABEL
+            ).rstrip()
         ):
             logger.debug("The external TLS certificate expiring.")
-            scope = UNIT_SCOPE  # external cert
+            internal = False
         elif (
             event.certificate.rstrip()
-            == self.charm.get_secret(APP_SCOPE, Config.TLS.SECRET_CERT_LABEL).rstrip()
+            == self.get_tls_secret(internal=True, label_name=Config.TLS.SECRET_CERT_LABEL).rstrip()
         ):
             logger.debug("The internal TLS certificate expiring.")
-            if not self.charm.unit.is_leader():
-                return
-            scope = APP_SCOPE  # internal cert
+
+            internal = True
         else:
             logger.error("An unknown certificate expiring.")
             return
 
         logger.debug("Generating a new Certificate Signing Request.")
-        key = self.charm.get_secret(scope, Config.TLS.SECRET_KEY_LABEL).encode("utf-8")
-        old_csr = self.charm.get_secret(scope, Config.TLS.SECRET_CSR_LABEL).encode("utf-8")
+        key = self.get_tls_secret(internal, Config.TLS.SECRET_KEY_LABEL).encode("utf-8")
+        old_csr = self.get_tls_secret(internal, Config.TLS.SECRET_CSR_LABEL).encode("utf-8")
         new_csr = generate_csr(
             private_key=key,
-            subject=self.get_host(self.charm.unit),
-            organization=self.charm.app.name,
+            subject=self._get_subject_name(),
+            organization=self._get_subject_name(),
             sans=self._get_sans(),
             sans_ip=[str(self.charm.model.get_binding(self.peer_relation).network.bind_address)],
         )
@@ -244,7 +291,7 @@ class MongoDBTLS(Object):
             new_certificate_signing_request=new_csr,
         )
 
-        self.charm.set_secret(scope, Config.TLS.SECRET_CSR_LABEL, new_csr.decode("utf-8"))
+        self.set_tls_secret(internal, Config.TLS.SECRET_CSR_LABEL, new_csr.decode("utf-8"))
 
     def _get_sans(self) -> List[str]:
         """Create a list of DNS names for a MongoDB unit.
@@ -258,26 +305,28 @@ class MongoDBTLS(Object):
             socket.getfqdn(),
             f"{self.charm.app.name}-{unit_id}.{self.charm.app.name}-endpoints",
             str(self.charm.model.get_binding(self.peer_relation).network.bind_address),
+            "localhost",
         ]
 
-    def get_tls_files(self, scope: Scopes) -> Tuple[Optional[str], Optional[str]]:
+    def get_tls_files(self, internal: bool) -> Tuple[Optional[str], Optional[str]]:
         """Prepare TLS files in special MongoDB way.
 
         MongoDB needs two files:
         — CA file should have a full chain.
         — PEM file should have private key and certificate without certificate chain.
         """
-        if not self.is_tls_enabled(scope):
+        scope = "internal" if internal else "external"
+        if not self.is_tls_enabled(internal):
             logging.debug(f"TLS disabled for {scope}")
             return None, None
         logging.debug(f"TLS *enabled* for {scope}, fetching data for CA and PEM files ")
 
-        ca = self.charm.get_secret(scope, Config.TLS.SECRET_CA_LABEL)
-        chain = self.charm.get_secret(scope, Config.TLS.SECRET_CHAIN_LABEL)
+        ca = self.get_tls_secret(internal, Config.TLS.SECRET_CA_LABEL)
+        chain = self.get_tls_secret(internal, Config.TLS.SECRET_CHAIN_LABEL)
         ca_file = chain if chain else ca
 
-        key = self.charm.get_secret(scope, Config.TLS.SECRET_KEY_LABEL)
-        cert = self.charm.get_secret(scope, Config.TLS.SECRET_CERT_LABEL)
+        key = self.get_tls_secret(internal, Config.TLS.SECRET_KEY_LABEL)
+        cert = self.get_tls_secret(internal, Config.TLS.SECRET_CERT_LABEL)
         pem_file = key
         if cert:
             pem_file = key + "\n" + cert if key else cert
@@ -287,6 +336,30 @@ class MongoDBTLS(Object):
     def get_host(self, unit: Unit):
         """Retrieves the hostname of the unit based on the substrate."""
         if self.substrate == "vm":
-            return self.charm._unit_ip(unit)
+            return self.charm.unit_ip(unit)
         else:
             return self.charm.get_hostname_for_unit(unit)
+
+    def set_tls_secret(self, internal: bool, label_name: str, contents: str) -> None:
+        """Sets TLS secret, based on whether or not it is related to internal connections."""
+        scope = "int" if internal else "ext"
+        label_name = f"{scope}-{label_name}"
+        self.charm.set_secret(UNIT_SCOPE, label_name, contents)
+
+    def get_tls_secret(self, internal: bool, label_name: str) -> str:
+        """Gets TLS secret, based on whether or not it is related to internal connections."""
+        scope = "int" if internal else "ext"
+        label_name = f"{scope}-{label_name}"
+        return self.charm.get_secret(UNIT_SCOPE, label_name)
+
+    def _get_subject_name(self) -> str:
+        """Generate the subject name for CSR."""
+        # In sharded MongoDB deployments it is a requirement that all subject names match across
+        # all cluster components. The config-server name is the source of truth across mongos and
+        # shard deployments.
+        if not self.charm.is_role(Config.Role.CONFIG_SERVER):
+            # until integrated with config-server use current app name as
+            # subject name
+            return self.charm.get_config_server_name() or self.charm.app.name
+
+        return self.charm.app.name

--- a/lib/charms/mongodb/v0/set_status.py
+++ b/lib/charms/mongodb/v0/set_status.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Code for handing statuses in the app and unit."""
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+import json
+
+from ops.charm import CharmBase
+from ops.framework import Object
+from ops.model import ActiveStatus, StatusBase, WaitingStatus
+
+from config import Config
+
+# The unique Charmhub library identifier, never change it
+LIBID = "9b0b9fac53244229aed5ffc5e62141eb"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 2
+
+
+class MongoDBStatusHandler(Object):
+    """Verifies versions across multiple integrated applications."""
+
+    def __init__(
+        self,
+        charm: CharmBase,
+    ) -> None:
+        """Constructor for CrossAppVersionChecker.
+
+        Args:
+            charm: charm to inherit from.
+        """
+        super().__init__(charm, None)
+        self.charm = charm
+
+        # TODO Future PR: handle update_status
+
+    # BEGIN Helpers
+
+    def set_and_share_status(self, status: StatusBase):
+        """Sets the charm status and shares to app status and config-server if applicable."""
+        # TODO Future Feature/Epic: process other statuses, i.e. only set provided status if its
+        # appropriate.
+        self.charm.unit.status = status
+
+        self.set_app_status()
+
+        if self.charm.is_role(Config.Role.SHARD):
+            self.share_status_to_config_server()
+
+    def set_app_status(self):
+        """TODO Future Feature/Epic: parse statuses and set a status for the entire app."""
+
+    def are_all_units_ready_for_upgrade(self) -> bool:
+        """Returns True if all charm units status's show that they are ready for upgrade."""
+        goal_state = self.charm.model._backend._run(
+            "goal-state", return_output=True, use_json=True
+        )
+        is_different_revision = self.charm.get_cluster_mismatched_revision_status()
+        for _, unit_state in goal_state["units"].items():
+            if unit_state["status"] == "active":
+                continue
+            if unit_state["status"] != "waiting":
+                return False
+
+            if not is_different_revision:
+                return False
+
+        return True
+
+    def are_shards_status_ready_for_upgrade(self) -> bool:
+        """Returns True if all integrated shards status's show that they are ready for upgrade.
+
+        A shard is ready for upgrade if it is either in the waiting for upgrade status or active
+        status.
+        """
+        if not self.charm.is_role(Config.Role.CONFIG_SERVER):
+            return False
+
+        for sharding_relation in self.charm.config_server.get_all_sharding_relations():
+            for unit in sharding_relation.units:
+                unit_data = sharding_relation.data[unit]
+                status_ready_for_upgrade = json.loads(
+                    unit_data.get(Config.Status.STATUS_READY_FOR_UPGRADE, None)
+                )
+                if not status_ready_for_upgrade:
+                    return False
+
+        return True
+
+    def share_status_to_config_server(self):
+        """Shares this shards status info to the config server."""
+        if not self.charm.is_role(Config.Role.SHARD):
+            return
+
+        if not (config_relation := self.charm.shard.get_config_server_relation()):
+            return
+
+        config_relation.data[self.charm.unit][Config.Status.STATUS_READY_FOR_UPGRADE] = json.dumps(
+            self.is_unit_status_ready_for_upgrade()
+        )
+
+    def is_unit_status_ready_for_upgrade(self) -> bool:
+        """Returns True if the status of the current unit reflects that it is ready for upgrade."""
+        current_status = self.charm.unit.status
+        status_message = current_status.message
+        if isinstance(current_status, ActiveStatus):
+            return True
+
+        if not isinstance(current_status, WaitingStatus):
+            return False
+
+        if status_message and "is not up-to date with config-server" in status_message:
+            return True
+
+        return False
+
+    # END: Helpers

--- a/src/charm.py
+++ b/src/charm.py
@@ -532,7 +532,6 @@ class MongoDBCharm(CharmBase):
         # Cannot check more advanced MongoDB statuses if mongod hasn't started.
         with MongoDBConnection(self.mongodb_config, "localhost", direct=True) as direct_mongo:
             if not direct_mongo.is_ready:
-                # self.unit.status = WaitingStatus("Waiting for MongoDB to start")
                 self.status.set_and_share_status(WaitingStatus("Waiting for MongoDB to start"))
                 return
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -268,15 +268,15 @@ class MongoDBCharm(CharmBase):
         return "db_initialised" in self.app_peer_data
 
     def is_role(self, role_name: str) -> bool:
-        """TODO: Implement this as part of sharding"""
+        """TODO: Implement this as part of sharding."""
         return False
 
     def has_config_server(self) -> bool:
-        """TODO: Implement this function as part of sharding"""
+        """TODO: Implement this function as part of sharding."""
         return False
 
     def get_config_server_name(self) -> None:
-        """TODO: Implement this function as part of sharding"""
+        """TODO: Implement this function as part of sharding."""
         return None
 
     @db_initialised.setter
@@ -396,6 +396,7 @@ class MongoDBCharm(CharmBase):
             return
 
     def is_db_service_ready(self) -> bool:
+        """Checks if the MongoDB service is ready to accept connections."""
         with MongoDBConnection(self.mongodb_config, "localhost", direct=True) as direct_mongo:
             return direct_mongo.is_ready
 
@@ -1034,7 +1035,7 @@ class MongoDBCharm(CharmBase):
     def push_file_to_container(
         self, container: Container, parent_dir: str, file_name: str, source: str
     ) -> None:
-        """Push the file on the container, with the right permissions"""
+        """Push the file on the container, with the right permissions."""
         container.push(
             f"{parent_dir}/{file_name}",
             source,

--- a/src/config.py
+++ b/src/config.py
@@ -72,6 +72,14 @@ class Config:
 
         Scopes = Literal[APP_SCOPE, UNIT_SCOPE]
 
+    class Role:
+        """Role config names for MongoDB Charm."""
+
+        CONFIG_SERVER = "config-server"
+        REPLICATION = "replication"
+        SHARD = "shard"
+        MONGOS = "mongos"
+
     class TLS:
         """TLS related config for MongoDB Charm."""
 

--- a/tests/integration/tls_tests/test_tls.py
+++ b/tests/integration/tls_tests/test_tls.py
@@ -8,6 +8,7 @@ import time
 import pytest
 from ops import Unit
 from pytest_operator.plugin import OpsTest
+import os
 
 from ..helpers import (
     check_or_scale_app,
@@ -36,56 +37,47 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.group(1)
-async def check_certs_correctly_distributed(ops_test: OpsTest, unit: Unit) -> None:
+async def check_certs_correctly_distributed(
+    ops_test: OpsTest, unit: Unit, app_name: str | None = None
+) -> None:
     """Comparing expected vs distributed certificates.
 
     Verifying certificates downloaded on the charm against the ones distributed by the TLS operator
     """
-    app_secret_id = await get_secret_id(ops_test, DATABASE_APP_NAME)
+    app_name = app_name or await get_app_name(ops_test)
     unit_secret_id = await get_secret_id(ops_test, unit.name)
-    app_secret_content = await get_secret_content(ops_test, app_secret_id)
     unit_secret_content = await get_secret_content(ops_test, unit_secret_id)
-    app_current_crt = app_secret_content["csr-secret"]
-    unit_current_crt = unit_secret_content["csr-secret"]
 
     # Get the values for certs from the relation, as provided by TLS Charm
     certificates_raw_data = await get_application_relation_data(
-        ops_test, DATABASE_APP_NAME, TLS_RELATION_NAME, "certificates"
+        ops_test, app_name, TLS_RELATION_NAME, "certificates"
     )
     certificates_data = json.loads(certificates_raw_data)
 
-    external_item = [
-        data
-        for data in certificates_data
-        if data["certificate_signing_request"].rstrip() == unit_current_crt.rstrip()
-    ][0]
-    internal_item = [
-        data
-        for data in certificates_data
-        if data["certificate_signing_request"].rstrip() == app_current_crt.rstrip()
-    ][0]
+    # compare the TLS resources stored on the disk of the unit with the ones from the TLS relation
+    for cert_type, cert_path in [("int", INTERNAL_CERT_PATH), ("ext", EXTERNAL_CERT_PATH)]:
+        unit_csr = unit_secret_content[f"{cert_type}-csr-secret"]
+        tls_item = [
+            data
+            for data in certificates_data
+            if data["certificate_signing_request"].rstrip() == unit_csr.rstrip()
+        ][0]
 
-    # Get a local copy of the external cert
-    external_copy_path = await scp_file_preserve_ctime(ops_test, unit.name, EXTERNAL_CERT_PATH)
+        # Read the content of the cert file stored in the unit
+        cert_file_copy_path = await scp_file_preserve_ctime(ops_test, unit.name, cert_path)
+        with open(cert_file_copy_path, mode="r") as f:
+            cert_file_content = f.read()
 
-    # Get the external cert value from the relation
-    relation_external_cert = "\n".join(external_item["chain"])
+        # cleanup the file
+        os.remove(cert_file_copy_path)
 
-    # CHECK: Compare if they are the same
-    with open(external_copy_path) as f:
-        external_contents_file = f.read()
-        assert relation_external_cert == external_contents_file
+        # Get the external cert value from the relation
+        relation_cert = "\n".join(tls_item["chain"]).strip()
 
-    # Get a local copy of the internal cert
-    internal_copy_path = await scp_file_preserve_ctime(ops_test, unit.name, INTERNAL_CERT_PATH)
-
-    # Get the external cert value from the relation
-    relation_internal_cert = "\n".join(internal_item["chain"])
-
-    # CHECK: Compare if they are the same
-    with open(internal_copy_path) as f:
-        internal_contents_file = f.read()
-        assert relation_internal_cert == internal_contents_file
+        # confirm that they match
+        assert (
+            relation_cert == cert_file_content
+        ), f"Relation Content for {cert_type}-cert:\n{relation_cert}\nFile Content:\n{cert_file_content}\nMismatch."
 
 
 @pytest.mark.group(1)
@@ -94,7 +86,7 @@ async def test_build_and_deploy(ops_test: OpsTest) -> None:
     """Build and deploy three units of MongoDB and one unit of TLS."""
     app_name = await get_app_name(ops_test)
     if app_name:
-        await check_or_scale_app(ops_test, app_name, 1)
+        await check_or_scale_app(ops_test, app_name, 3)
     else:
         app_name = DATABASE_APP_NAME
         async with ops_test.fast_forward():
@@ -102,7 +94,7 @@ async def test_build_and_deploy(ops_test: OpsTest) -> None:
             resources = {
                 "mongodb-image": METADATA["resources"]["mongodb-image"]["upstream-source"]
             }
-            await ops_test.model.deploy(my_charm, num_units=1, resources=resources, series="jammy")
+            await ops_test.model.deploy(my_charm, num_units=3, resources=resources, series="jammy")
             await ops_test.model.wait_for_idle(apps=[app_name], status="active", timeout=2000)
 
     tls_app_deployed = False
@@ -145,11 +137,13 @@ async def test_rotate_tls_key(ops_test: OpsTest) -> None:
 
     This test rotates tls private keys to randomly generated keys.
     """
-    app_name = await get_app_name(ops_test)
     # dict of values for cert file certion and mongod service start times. After resetting the
     # private keys these certificates should be updated and the mongod service should be
     # restarted
     original_tls_times = {}
+
+    app_name = await get_app_name(ops_test)
+
     for unit in ops_test.model.applications[app_name].units:
         original_tls_times[unit.name] = {}
         original_tls_times[unit.name]["external_cert"] = await time_file_created(
@@ -184,7 +178,7 @@ async def test_rotate_tls_key(ops_test: OpsTest) -> None:
         new_internal_cert_time = await time_file_created(ops_test, unit.name, INTERNAL_CERT_PATH)
         new_mongod_service_time = await time_process_started(ops_test, unit.name, DB_SERVICE)
 
-        await check_certs_correctly_distributed(ops_test, unit)
+        await check_certs_correctly_distributed(ops_test, unit, app_name=app_name)
 
         assert (
             new_external_cert_time > original_tls_times[unit.name]["external_cert"]

--- a/tests/integration/tls_tests/test_tls.py
+++ b/tests/integration/tls_tests/test_tls.py
@@ -3,12 +3,12 @@
 # See LICENSE file for licensing details.
 import json
 import logging
+import os
 import time
 
 import pytest
 from ops import Unit
 from pytest_operator.plugin import OpsTest
-import os
 
 from ..helpers import (
     check_or_scale_app,


### PR DESCRIPTION
The TLS tests were artifically passing because it was impossible to integrate mongodb-k8s (multiple units) and self-signed certificates because it would get stuck in `secrets-changed` forever.

Updating the libraries, and fixing the integration between the MongoDB TLS library and the Charm's source was almost sufficient, some test methods needed to be updated as well in order to be in line with https://github.com/canonical/mongodb-operator.

A few minor improvements as well in the source charm in order to build reusable methods for pushing files to container and checking DB readiness.