### PR TITLE
[DPE-4874] [DPE-4868] [DPE-4870] Update libs for log rotate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@ venv/
 build/
 *.charm
 
-.coverage
+.coverage*
 __pycache__/
 *.py[cod]
 

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -55,3 +55,6 @@ storage:
   mongodb:
     type: filesystem
     location: /var/lib/mongodb
+  mongodb-logs:
+    type: filesystem
+    location: /var/log/mongodb

--- a/poetry.lock
+++ b/poetry.lock
@@ -837,13 +837,13 @@ testing = ["Django", "attrs", "colorama", "docopt", "pytest (<7.0.0)"]
 
 [[package]]
 name = "jinja2"
-version = "3.1.4"
+version = "3.1.3"
 description = "A very fast and expressive template engine."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "jinja2-3.1.4-py3-none-any.whl", hash = "sha256:bc5dd2abb727a5319567b7a813e6a2e7318c39f4f487cfe6c89c6f9c7d25197d"},
-    {file = "jinja2-3.1.4.tar.gz", hash = "sha256:4a3aee7acbbe7303aede8e9648d13b8bf88a429282aa6122a993f0ac800cb369"},
+    {file = "Jinja2-3.1.3-py3-none-any.whl", hash = "sha256:7d6d50dd97d52cbc355597bd845fabfbac3f551e1f99619e39a35ce8c370b5fa"},
+    {file = "Jinja2-3.1.3.tar.gz", hash = "sha256:ac8bd6544d4bb2c9792bf3a159e80bba8fda7f07e81bc3aed565432d5925ba90"},
 ]
 
 [package.dependencies]
@@ -2281,4 +2281,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10.12"
-content-hash = "03ebc806fd195143542cd612a25e20e05ba13135b7bc32d166be9d7a498f433a"
+content-hash = "d9c833d4c21962326172ec5b9498772a34d0138508560b9d7be7c77bbc261e17"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ ops = "^2.12.0"
 pymongo = "^4.7.1"
 tenacity = "^8.2.3"
 pyyaml = "^6.0.1"
+jinja2 = "3.1.3"
 
 [tool.poetry.group.charm-libs.dependencies]
 ops = "^2.12.0"

--- a/src/charm.py
+++ b/src/charm.py
@@ -10,20 +10,11 @@ from typing import Dict, List, Optional, Set
 
 from charms.grafana_k8s.v0.grafana_dashboard import GrafanaDashboardProvider
 from charms.loki_k8s.v0.loki_push_api import LogProxyConsumer
-from charms.mongodb.v1.helpers import (
-    build_unit_status,
-    generate_keyfile,
-    generate_password,
-    get_create_user_cmd,
-    get_mongod_args,
-)
 from charms.mongodb.v0.mongodb import (
     MongoDBConfiguration,
     MongoDBConnection,
     NotReadyError,
 )
-from charms.mongodb.v1.mongodb_backups import S3_RELATION, MongoDBBackups
-from charms.mongodb.v1.mongodb_provider import MongoDBProvider
 from charms.mongodb.v0.mongodb_secrets import SecretCache, generate_secret_label
 from charms.mongodb.v0.mongodb_tls import MongoDBTLS
 from charms.mongodb.v0.set_status import MongoDBStatusHandler
@@ -34,6 +25,15 @@ from charms.mongodb.v0.users import (
     MonitorUser,
     OperatorUser,
 )
+from charms.mongodb.v1.helpers import (
+    build_unit_status,
+    generate_keyfile,
+    generate_password,
+    get_create_user_cmd,
+    get_mongod_args,
+)
+from charms.mongodb.v1.mongodb_backups import S3_RELATION, MongoDBBackups
+from charms.mongodb.v1.mongodb_provider import MongoDBProvider
 from charms.prometheus_k8s.v0.prometheus_scrape import MetricsEndpointProvider
 from ops.charm import (
     ActionEvent,

--- a/src/charm.py
+++ b/src/charm.py
@@ -356,7 +356,13 @@ class MongoDBCharm(CharmBase):
             return pure_id1 == pure_id2
         return False
 
-    # END: generic helper methods
+    def is_relation_feasible(self, rel_interface) -> bool:
+        """Returns true if the proposed relation is feasible.
+
+        TODO implement this in a future PR as part of sharding
+        """
+        logger.debug("checking if provided relation %s is feasible", rel_interface)
+        return True
 
     # BEGIN: charm events
     def _on_mongod_pebble_ready(self, event) -> None:

--- a/src/config.py
+++ b/src/config.py
@@ -14,7 +14,7 @@ class Config:
     UNIX_USER = "mongodb"
     UNIX_GROUP = "mongodb"
     DATA_DIR = "/var/lib/mongodb"
-    LOG_DIR = "/var/lib/mongodb"
+    LOG_DIR = "/var/log/mongodb"
     CONF_DIR = "/etc/mongod"
     MONGODB_LOG_FILENAME = "mongodb.log"
     LICENSE_PATH = "/licenses/LICENSE"
@@ -35,6 +35,7 @@ class Config:
         """Audit log related configuration."""
 
         FORMAT = "JSON"
+        DESTINATION = "file"
         FILE_NAME = "audit.log"
 
     class Backup:
@@ -44,6 +45,12 @@ class Config:
         URI_PARAM_NAME = "pbm-uri"
         PBM_PATH = "/usr/bin/pbm"
         PBM_CONFIG_FILE_PATH = "/etc/pbm_config.yaml"
+
+    class LogRotate:
+        """Log rotate related constants."""
+
+        MAX_LOG_SIZE = "50M"
+        MAX_ROTATIONS_TO_KEEP = 10
 
     class Monitoring:
         """Monitoring related config for MongoDB Charm."""

--- a/tests/integration/backup_tests/test_backups.py
+++ b/tests/integration/backup_tests/test_backups.py
@@ -71,6 +71,7 @@ async def add_writes_to_db(ops_test: OpsTest):
     await clear_writes_action.wait()
 
 
+@pytest.mark.skip("Skipping tests until fixing backup tests are addressed (DPE-4264).")
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
 async def test_build_and_deploy(ops_test: OpsTest) -> None:
@@ -107,6 +108,7 @@ async def test_build_and_deploy(ops_test: OpsTest) -> None:
     await ops_test.model.wait_for_idle()
 
 
+@pytest.mark.skip("Skipping tests until fixing backup tests are addressed (DPE-4264).")
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
 async def test_blocked_incorrect_creds(ops_test: OpsTest) -> None:
@@ -137,6 +139,7 @@ async def test_blocked_incorrect_creds(ops_test: OpsTest) -> None:
     assert db_unit.workload_status_message == "s3 credentials are incorrect."
 
 
+@pytest.mark.skip("Skipping tests until fixing backup tests are addressed (DPE-4264).")
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
 async def test_blocked_incorrect_conf(ops_test: OpsTest) -> None:
@@ -155,6 +158,7 @@ async def test_blocked_incorrect_conf(ops_test: OpsTest) -> None:
     assert db_unit.workload_status_message == "s3 configurations are incompatible."
 
 
+@pytest.mark.skip("Skipping tests until fixing backup tests are addressed (DPE-4264).")
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
 async def test_ready_correct_conf(ops_test: OpsTest) -> None:
@@ -179,6 +183,7 @@ async def test_ready_correct_conf(ops_test: OpsTest) -> None:
     )
 
 
+@pytest.mark.skip("Skipping tests until fixing backup tests are addressed (DPE-4264).")
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
 async def test_create_and_list_backups(ops_test: OpsTest) -> None:
@@ -207,6 +212,7 @@ async def test_create_and_list_backups(ops_test: OpsTest) -> None:
         assert backups == 1, "Backup not created."
 
 
+@pytest.mark.skip("Skipping tests until fixing backup tests are addressed (DPE-4264).")
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
 async def test_multi_backup(ops_test: OpsTest, continuous_writes_to_db) -> None:
@@ -294,6 +300,7 @@ async def test_multi_backup(ops_test: OpsTest, continuous_writes_to_db) -> None:
         assert backups == 2, "Backup not created in bucket on AWS."
 
 
+@pytest.mark.skip("Skipping tests until fixing backup tests are addressed (DPE-4264).")
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
 async def test_restore(ops_test: OpsTest, continuous_writes_to_db) -> None:
@@ -355,6 +362,7 @@ async def test_restore(ops_test: OpsTest, continuous_writes_to_db) -> None:
 
 
 # TODO remove unstable mark once juju issue with secrets is resolved
+@pytest.mark.skip("Skipping tests until fixing backup tests are addressed (DPE-4264).")
 @pytest.mark.group(1)
 @pytest.mark.unstable
 @pytest.mark.parametrize("cloud_provider", ["AWS", "GCP"])
@@ -465,6 +473,7 @@ async def test_restore_new_cluster(ops_test: OpsTest, continuous_writes_to_db, c
     # await helpers.destroy_cluster(ops_test, cluster_name=NEW_CLUSTER)
 
 
+@pytest.mark.skip("Skipping tests until fixing backup tests are addressed (DPE-4264).")
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
 async def test_update_backup_password(ops_test: OpsTest) -> None:

--- a/tests/integration/backup_tests/test_backups.py
+++ b/tests/integration/backup_tests/test_backups.py
@@ -71,7 +71,6 @@ async def add_writes_to_db(ops_test: OpsTest):
     await clear_writes_action.wait()
 
 
-@pytest.mark.skip("Skipping tests until fixing backup tests are addressed (DPE-4264).")
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
 async def test_build_and_deploy(ops_test: OpsTest) -> None:
@@ -108,7 +107,6 @@ async def test_build_and_deploy(ops_test: OpsTest) -> None:
     await ops_test.model.wait_for_idle()
 
 
-@pytest.mark.skip("Skipping tests until fixing backup tests are addressed (DPE-4264).")
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
 async def test_blocked_incorrect_creds(ops_test: OpsTest) -> None:
@@ -139,7 +137,6 @@ async def test_blocked_incorrect_creds(ops_test: OpsTest) -> None:
     assert db_unit.workload_status_message == "s3 credentials are incorrect."
 
 
-@pytest.mark.skip("Skipping tests until fixing backup tests are addressed (DPE-4264).")
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
 async def test_blocked_incorrect_conf(ops_test: OpsTest) -> None:
@@ -158,7 +155,6 @@ async def test_blocked_incorrect_conf(ops_test: OpsTest) -> None:
     assert db_unit.workload_status_message == "s3 configurations are incompatible."
 
 
-@pytest.mark.skip("Skipping tests until fixing backup tests are addressed (DPE-4264).")
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
 async def test_ready_correct_conf(ops_test: OpsTest) -> None:
@@ -183,7 +179,6 @@ async def test_ready_correct_conf(ops_test: OpsTest) -> None:
     )
 
 
-@pytest.mark.skip("Skipping tests until fixing backup tests are addressed (DPE-4264).")
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
 async def test_create_and_list_backups(ops_test: OpsTest) -> None:
@@ -212,7 +207,6 @@ async def test_create_and_list_backups(ops_test: OpsTest) -> None:
         assert backups == 1, "Backup not created."
 
 
-@pytest.mark.skip("Skipping tests until fixing backup tests are addressed (DPE-4264).")
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
 async def test_multi_backup(ops_test: OpsTest, continuous_writes_to_db) -> None:
@@ -300,7 +294,6 @@ async def test_multi_backup(ops_test: OpsTest, continuous_writes_to_db) -> None:
         assert backups == 2, "Backup not created in bucket on AWS."
 
 
-@pytest.mark.skip("Skipping tests until fixing backup tests are addressed (DPE-4264).")
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
 async def test_restore(ops_test: OpsTest, continuous_writes_to_db) -> None:
@@ -362,7 +355,6 @@ async def test_restore(ops_test: OpsTest, continuous_writes_to_db) -> None:
 
 
 # TODO remove unstable mark once juju issue with secrets is resolved
-@pytest.mark.skip("Skipping tests until fixing backup tests are addressed (DPE-4264).")
 @pytest.mark.group(1)
 @pytest.mark.unstable
 @pytest.mark.parametrize("cloud_provider", ["AWS", "GCP"])
@@ -473,7 +465,6 @@ async def test_restore_new_cluster(ops_test: OpsTest, continuous_writes_to_db, c
     # await helpers.destroy_cluster(ops_test, cluster_name=NEW_CLUSTER)
 
 
-@pytest.mark.skip("Skipping tests until fixing backup tests are addressed (DPE-4264).")
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
 async def test_update_backup_password(ops_test: OpsTest) -> None:

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -813,7 +813,7 @@ class TestCharm(unittest.TestCase):
         self.harness.charm._on_set_password(action_event)
         connect_exporter.assert_called()
 
-    @patch("charm.MongoDBBackups._get_pbm_status")
+    @patch("charm.MongoDBBackups.get_pbm_status")
     @patch("charm.MongoDBCharm.has_backup_service")
     @patch("charm.MongoDBConnection")
     @patch("charm.MongoDBCharm._connect_mongodb_exporter")
@@ -845,7 +845,7 @@ class TestCharm(unittest.TestCase):
         assert "password" in args_pw
         assert args_pw["password"] == pw
 
-    @patch("charm.MongoDBBackups._get_pbm_status")
+    @patch("charm.MongoDBBackups.get_pbm_status")
     @patch("charm.MongoDBCharm.has_backup_service")
     @patch("charm.MongoDBConnection")
     @patch("charm.MongoDBCharm._connect_mongodb_exporter")
@@ -1003,7 +1003,7 @@ class TestCharm(unittest.TestCase):
 
     @patch_network_get(private_address="1.1.1.1")
     @patch("charm.MongoDBCharm.has_backup_service")
-    @patch("charm.MongoDBBackups._get_pbm_status")
+    @patch("charm.MongoDBBackups.get_pbm_status")
     def test_set_backup_password_pbm_busy(self, pbm_status, has_backup_service):
         """Tests changes to passwords fail when pbm is restoring/backing up."""
         self.harness.set_leader(True)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -7,7 +7,7 @@ from unittest import mock
 from unittest.mock import MagicMock, patch
 
 import pytest
-from charms.mongodb.v0.helpers import CONF_DIR, DATA_DIR, KEY_FILE
+from charms.mongodb.v1.helpers import CONF_DIR, DATA_DIR, KEY_FILE
 from ops.model import ActiveStatus, MaintenanceStatus, ModelError
 from ops.pebble import APIError, ExecError, PathError, ProtocolError
 from ops.testing import Harness
@@ -75,11 +75,13 @@ class TestCharm(unittest.TestCase):
                         "mongod --bind_ip_all "
                         "--replSet=mongodb-k8s "
                         f"--dbpath={DATA_DIR} "
+                        "--port=27017 "
+                        "--setParameter processUmask=037 "
+                        "--logRotate reopen --logappend --logpath=/var/log/mongodb/mongodb.log "
                         "--auditDestination=file "
                         "--auditFormat=JSON "
-                        "--auditPath=/var/lib/mongodb/audit.log "
-                        "--logpath=/var/lib/mongodb/mongodb.log --auth "
-                        "--clusterAuthMode=keyFile "
+                        "--auditPath=/var/log/mongodb/audit.log "
+                        "--auth --clusterAuthMode=keyFile "
                         f"--keyFile={CONF_DIR}/{KEY_FILE} \n"
                     ),
                     "startup": "enabled",

--- a/tests/unit/test_mongodb_backups.py
+++ b/tests/unit/test_mongodb_backups.py
@@ -49,7 +49,7 @@ class TestMongoBackups(unittest.TestCase):
         container = self.harness.model.unit.get_container("mongod")
         self.harness.set_can_connect(container, True)
         pbm_command.side_effect = ModelError("service pbm-agent not found")
-        self.assertTrue(isinstance(self.harness.charm.backups._get_pbm_status(), BlockedStatus))
+        self.assertTrue(isinstance(self.harness.charm.backups.get_pbm_status(), BlockedStatus))
 
     @patch("charm.MongoDBCharm.has_backup_service")
     @patch("charm.MongoDBCharm.run_pbm_command")
@@ -64,7 +64,7 @@ class TestMongoBackups(unittest.TestCase):
         pbm_command.return_value = (
             '{"running":{"type":"resync","opID":"64f5cc22a73b330c3880e3b2"}}'
         )
-        self.assertTrue(isinstance(self.harness.charm.backups._get_pbm_status(), WaitingStatus))
+        self.assertTrue(isinstance(self.harness.charm.backups.get_pbm_status(), WaitingStatus))
 
     @patch("charm.MongoDBCharm.has_backup_service")
     @patch("charm.MongoDBCharm.run_pbm_command")
@@ -77,7 +77,7 @@ class TestMongoBackups(unittest.TestCase):
         self.harness.set_can_connect(container, True)
         service.return_value = "pbm"
         pbm_command.return_value = '{"running":{}}'
-        self.assertTrue(isinstance(self.harness.charm.backups._get_pbm_status(), ActiveStatus))
+        self.assertTrue(isinstance(self.harness.charm.backups.get_pbm_status(), ActiveStatus))
 
     @patch("charm.MongoDBCharm.has_backup_service")
     @patch("charm.MongoDBCharm.run_pbm_command")
@@ -92,7 +92,7 @@ class TestMongoBackups(unittest.TestCase):
         pbm_command.side_effect = ExecError(
             command=["/usr/bin/pbm", "status"], exit_code=1, stdout="status code: 403", stderr=""
         )
-        self.assertTrue(isinstance(self.harness.charm.backups._get_pbm_status(), BlockedStatus))
+        self.assertTrue(isinstance(self.harness.charm.backups.get_pbm_status(), BlockedStatus))
 
     @patch("charm.MongoDBCharm.has_backup_service")
     @patch("charm.MongoDBCharm.run_pbm_command")
@@ -107,7 +107,7 @@ class TestMongoBackups(unittest.TestCase):
         pbm_command.side_effect = ExecError(
             command=["/usr/bin/pbm", "status"], exit_code=1, stdout="status code: 404", stderr=""
         )
-        self.assertTrue(isinstance(self.harness.charm.backups._get_pbm_status(), BlockedStatus))
+        self.assertTrue(isinstance(self.harness.charm.backups.get_pbm_status(), BlockedStatus))
 
     @patch("charms.mongodb.v0.mongodb_backups.wait_fixed")
     @patch("charms.mongodb.v0.mongodb_backups.stop_after_attempt")
@@ -153,7 +153,7 @@ class TestMongoBackups(unittest.TestCase):
     @patch("ops.model.Container.start")
     @patch("charm.MongoDBCharm.has_backup_service")
     @patch("charm.MongoDBCharm.run_pbm_command")
-    @patch("charm.MongoDBBackups._get_pbm_status")
+    @patch("charm.MongoDBBackups.get_pbm_status")
     @patch("charms.mongodb.v0.mongodb_backups.wait_fixed")
     @patch("charms.mongodb.v0.mongodb_backups.stop_after_attempt")
     def test_verify_resync_syncing(
@@ -183,7 +183,7 @@ class TestMongoBackups(unittest.TestCase):
     @patch("charms.mongodb.v0.mongodb_backups.wait_fixed")
     @patch("charms.mongodb.v0.mongodb_backups.stop_after_attempt")
     @patch("charm.MongoDBCharm.has_backup_service")
-    @patch("charm.MongoDBBackups._get_pbm_status")
+    @patch("charm.MongoDBBackups.get_pbm_status")
     def test_resync_config_options_failure(
         self, pbm_status, service, retry_stop, retry_wait, start
     ):
@@ -202,7 +202,7 @@ class TestMongoBackups(unittest.TestCase):
     @patch("ops.model.Container.restart")
     @patch("ops.model.Container.start")
     @patch("charm.MongoDBCharm.has_backup_service")
-    @patch("charm.MongoDBBackups._get_pbm_status")
+    @patch("charm.MongoDBBackups.get_pbm_status")
     def test_resync_config_restart(
         self, pbm_status, service, start, restart, retry_stop, retry_wait
     ):
@@ -298,7 +298,7 @@ class TestMongoBackups(unittest.TestCase):
     @patch("charm.MongoDBBackups._resync_config_options")
     @patch("ops.framework.EventBase.defer")
     @patch("charm.MongoDBCharm.has_backup_service")
-    @patch("charm.MongoDBBackups._get_pbm_status")
+    @patch("charm.MongoDBBackups.get_pbm_status")
     def test_s3_credentials_config_error(
         self, pbm_status, service, defer, resync, _set_config_options
     ):
@@ -328,7 +328,7 @@ class TestMongoBackups(unittest.TestCase):
     @patch("charm.MongoDBBackups._resync_config_options")
     @patch("ops.framework.EventBase.defer")
     @patch("charm.MongoDBCharm.has_backup_service")
-    @patch("charm.MongoDBBackups._get_pbm_status")
+    @patch("charm.MongoDBBackups.get_pbm_status")
     def test_s3_credentials_syncing(self, pbm_status, service, defer, resync, _set_config_options):
         """Test charm defers when more time is needed to sync pbm credentials."""
         container = self.harness.model.unit.get_container("mongod")
@@ -357,7 +357,7 @@ class TestMongoBackups(unittest.TestCase):
     @patch("charm.MongoDBBackups._resync_config_options")
     @patch("ops.framework.EventBase.defer")
     @patch("charm.MongoDBCharm.has_backup_service")
-    @patch("charm.MongoDBBackups._get_pbm_status")
+    @patch("charm.MongoDBBackups.get_pbm_status")
     def test_s3_credentials_pbm_busy(
         self, pbm_status, service, defer, resync, _set_config_options
     ):
@@ -422,7 +422,7 @@ class TestMongoBackups(unittest.TestCase):
 
     @patch("charm.MongoDBCharm.has_backup_service")
     @patch("charm.MongoDBCharm.run_pbm_command")
-    @patch("charm.MongoDBBackups._get_pbm_status")
+    @patch("charm.MongoDBBackups.get_pbm_status")
     def test_backup_failed(self, pbm_status, pbm_command, service):
         """Verifies backup is fails if the pbm command failed."""
         container = self.harness.model.unit.get_container("mongod")
@@ -490,7 +490,7 @@ class TestMongoBackups(unittest.TestCase):
 
     @patch("charm.MongoDBCharm.has_backup_service")
     @patch("charm.MongoDBCharm.run_pbm_command")
-    @patch("charm.MongoDBBackups._get_pbm_status")
+    @patch("charm.MongoDBBackups.get_pbm_status")
     def test_backup_list_failed(self, pbm_status, pbm_command, service):
         """Verifies backup list fails if the pbm command fails."""
         mock_pbm_snap = mock.Mock()
@@ -603,7 +603,7 @@ class TestMongoBackups(unittest.TestCase):
 
     @patch("charm.MongoDBCharm.has_backup_service")
     @patch("charm.MongoDBCharm.run_pbm_command")
-    @patch("charm.MongoDBBackups._get_pbm_status")
+    @patch("charm.MongoDBBackups.get_pbm_status")
     def test_restore_wrong_cred(self, pbm_status, pbm_command, service):
         """Verifies restore is fails if the credentials are incorrect."""
         action_event = mock.Mock()
@@ -622,7 +622,7 @@ class TestMongoBackups(unittest.TestCase):
 
     @patch("charm.MongoDBCharm.has_backup_service")
     @patch("charm.MongoDBCharm.run_pbm_command")
-    @patch("charm.MongoDBBackups._get_pbm_status")
+    @patch("charm.MongoDBBackups.get_pbm_status")
     def test_restore_failed(self, pbm_status, pbm_command, service):
         """Verifies restore is fails if the pbm command failed."""
         action_event = mock.Mock()
@@ -694,9 +694,7 @@ class TestMongoBackups(unittest.TestCase):
 
         service.return_value = "pbm"
         run_pbm_command.return_value = '{"running":{"type":"backup","name":"2023-09-04T12:15:58Z","startTS":1693829759,"status":"oplog backup","opID":"64f5ca7e777e294530289465"}}'
-        self.assertTrue(
-            isinstance(self.harness.charm.backups._get_pbm_status(), MaintenanceStatus)
-        )
+        self.assertTrue(isinstance(self.harness.charm.backups.get_pbm_status(), MaintenanceStatus))
 
     def test_current_pbm_op(self):
         """Test if _current_pbm_op can identify the operation pbm is running."""

--- a/tests/unit/test_mongodb_provider.py
+++ b/tests/unit/test_mongodb_provider.py
@@ -107,7 +107,7 @@ class TestMongoProvider(unittest.TestCase):
                     self.harness.remove_relation_unit(relation_id, "consumer/0")
 
     @patch_network_get(private_address="1.1.1.1")
-    @patch("charms.mongodb.v0.mongodb_provider.MongoDBConnection")
+    @patch("charms.mongodb.v1.mongodb_provider.MongoDBConnection")
     def test_oversee_users_get_users_failure(self, connection):
         """Verifies that when unable to retrieve users from mongod an exception is raised."""
         for dep_id in DEPARTED_IDS:
@@ -120,7 +120,7 @@ class TestMongoProvider(unittest.TestCase):
 
     @patch_network_get(private_address="1.1.1.1")
     @patch("charm.MongoDBProvider._get_users_from_relations")
-    @patch("charms.mongodb.v0.mongodb_provider.MongoDBConnection")
+    @patch("charms.mongodb.v1.mongodb_provider.MongoDBConnection")
     def test_oversee_users_drop_user_failure(self, connection, relation_users):
         """Verifies that when unable to drop users from mongod an exception is raised."""
         # presets, such that there is a need to drop users.
@@ -140,7 +140,7 @@ class TestMongoProvider(unittest.TestCase):
 
     @patch_network_get(private_address="1.1.1.1")
     @patch("charm.MongoDBProvider._get_users_from_relations")
-    @patch("charms.mongodb.v0.mongodb_provider.MongoDBConnection")
+    @patch("charms.mongodb.v1.mongodb_provider.MongoDBConnection")
     def test_oversee_users_get_config_failure(self, connection, relation_users):
         """Verifies that when users do not match necessary schema an AssertionError is raised."""
         # presets, such that the need to create user relations is triggered. Further presets
@@ -159,7 +159,7 @@ class TestMongoProvider(unittest.TestCase):
     @patch("charm.MongoDBProvider._set_relation")
     @patch("charm.MongoDBProvider._get_config")
     @patch("charm.MongoDBProvider._get_users_from_relations")
-    @patch("charms.mongodb.v0.mongodb_provider.MongoDBConnection")
+    @patch("charms.mongodb.v1.mongodb_provider.MongoDBConnection")
     @patch("charm.MongoDBProvider._diff")
     def test_oversee_users_no_config_database(
         self, diff, connection, relation_users, get_config, set_relation
@@ -182,7 +182,7 @@ class TestMongoProvider(unittest.TestCase):
     @patch("charm.MongoDBProvider._set_relation")
     @patch("charm.MongoDBProvider._get_config")
     @patch("charm.MongoDBProvider._get_users_from_relations")
-    @patch("charms.mongodb.v0.mongodb_provider.MongoDBConnection")
+    @patch("charms.mongodb.v1.mongodb_provider.MongoDBConnection")
     def test_oversee_users_create_user_failure(
         self, connection, relation_users, get_config, set_relation
     ):
@@ -203,7 +203,7 @@ class TestMongoProvider(unittest.TestCase):
     @patch_network_get(private_address="1.1.1.1")
     @patch("charm.MongoDBProvider._get_config")
     @patch("charm.MongoDBProvider._get_users_from_relations")
-    @patch("charms.mongodb.v0.mongodb_provider.MongoDBConnection")
+    @patch("charms.mongodb.v1.mongodb_provider.MongoDBConnection")
     def test_oversee_users_set_relation_failure(self, connection, relation_users, get_config):
         """Verifies that when adding a user with an invalid name that an exception is raised."""
         # presets, such that the need to create user relations is triggered and user naming such
@@ -222,7 +222,7 @@ class TestMongoProvider(unittest.TestCase):
 
     @patch_network_get(private_address="1.1.1.1")
     @patch("charm.MongoDBProvider._get_users_from_relations")
-    @patch("charms.mongodb.v0.mongodb_provider.MongoDBConnection")
+    @patch("charms.mongodb.v1.mongodb_provider.MongoDBConnection")
     def test_oversee_users_update_get_config_failure(self, connection, relation_users):
         """Verifies that when updating a user with an invalid name that an exception is raised."""
         # presets, such that the need to update user relations is triggered and user naming such
@@ -240,7 +240,7 @@ class TestMongoProvider(unittest.TestCase):
     @patch_network_get(private_address="1.1.1.1")
     @patch("charm.MongoDBProvider._get_config")
     @patch("charm.MongoDBProvider._get_users_from_relations")
-    @patch("charms.mongodb.v0.mongodb_provider.MongoDBConnection")
+    @patch("charms.mongodb.v1.mongodb_provider.MongoDBConnection")
     def test_oversee_users_update_user_failure(self, connection, relation_users, get_config):
         """Verifies that when updating users fails an exception is raised."""
         # presets, such that the need to update user relations is triggered
@@ -259,7 +259,7 @@ class TestMongoProvider(unittest.TestCase):
     @patch_network_get(private_address="1.1.1.1")
     @patch("charm.MongoDBProvider._get_databases_from_relations")
     @patch("charm.MongoDBProvider._get_users_from_relations")
-    @patch("charms.mongodb.v0.mongodb_provider.MongoDBConnection")
+    @patch("charms.mongodb.v1.mongodb_provider.MongoDBConnection")
     def test_oversee_users_no_auto_delete(
         self, connection, relation_users, databases_from_relations
     ):
@@ -276,7 +276,7 @@ class TestMongoProvider(unittest.TestCase):
 
     @patch_network_get(private_address="1.1.1.1")
     @patch("charm.MongoDBProvider._get_users_from_relations")
-    @patch("charms.mongodb.v0.mongodb_provider.MongoDBConnection")
+    @patch("charms.mongodb.v1.mongodb_provider.MongoDBConnection")
     def test_oversee_users_mongo_databases_failure(self, connection, relation_users):
         """Verifies failures in checking for databases with mongod result in raised exceptions."""
         self.harness.update_config({"auto-delete": True})
@@ -294,7 +294,7 @@ class TestMongoProvider(unittest.TestCase):
     @patch_network_get(private_address="1.1.1.1")
     @patch("charm.MongoDBProvider._get_databases_from_relations")
     @patch("charm.MongoDBProvider._get_users_from_relations")
-    @patch("charms.mongodb.v0.mongodb_provider.MongoDBConnection")
+    @patch("charms.mongodb.v1.mongodb_provider.MongoDBConnection")
     def test_oversee_users_drop_database_failure(
         self, connection, relation_users, databases_from_relations
     ):


### PR DESCRIPTION
## Problem
The code for supporting log rotate is on the shared mongodb libs for `v1` - this charm uses mostly `v0` libs

## Solution
1. Update the necessary libs for log rotation to `v1`
2. Make corresponding changes in the charm such that these changes do not break the charm
3. 1+2 break tests, update them. 

## Future work
1. Update all remaining libs to their associated `v1` version
2. Implement log rotate
3. Further improve Ha tests once log rotate is fully added