### PR TITLE
[DPE-4911]: Fix flaky relations test

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -846,7 +846,7 @@ class MongoDBCharm(CharmBase):
         It is needed to install mongodb-clients inside the charm container
         to make this function work correctly.
         """
-        if self._is_user_created(OperatorUser):
+        if self._is_user_created(OperatorUser) or not self.unit.is_leader():
             return
 
         container = self.unit.get_container(Config.CONTAINER_NAME)

--- a/tests/integration/backup_tests/helpers.py
+++ b/tests/integration/backup_tests/helpers.py
@@ -119,21 +119,6 @@ async def set_credentials(ops_test: OpsTest, cloud: str) -> None:
     await action.wait()
 
 
-def is_relation_joined(ops_test: OpsTest, endpoint_one: str, endpoint_two: str) -> bool:
-    """Check if a relation is joined.
-
-    Args:
-        ops_test: The ops test object passed into every test case
-        endpoint_one: The first endpoint of the relation
-        endpoint_two: The second endpoint of the relation
-    """
-    for rel in ops_test.model.relations:
-        endpoints = [endpoint.name for endpoint in rel.endpoints]
-        if endpoint_one in endpoints and endpoint_two in endpoints:
-            return True
-    return False
-
-
 async def insert_unwanted_data(ops_test: OpsTest) -> None:
     """Inserts the data into the MongoDB cluster via primary replica."""
     app = await app_name(ops_test)

--- a/tests/integration/backup_tests/test_backups.py
+++ b/tests/integration/backup_tests/test_backups.py
@@ -15,7 +15,7 @@ from pytest_operator.plugin import OpsTest
 from tenacity import RetryError, Retrying, stop_after_delay, wait_fixed
 
 from ..ha_tests import helpers as ha_helpers
-from ..helpers import check_or_scale_app, get_app_name
+from ..helpers import check_or_scale_app, get_app_name, is_relation_joined
 from . import helpers
 
 S3_APP_NAME = "s3-integrator"
@@ -125,7 +125,7 @@ async def test_blocked_incorrect_creds(ops_test: OpsTest) -> None:
     await ops_test.model.wait_for_idle(apps=[S3_APP_NAME], status="active")
     await ops_test.model.integrate(S3_APP_NAME, db_app_name)
     await ops_test.model.block_until(
-        lambda: helpers.is_relation_joined(ops_test, ENDPOINT, ENDPOINT) is True,
+        lambda: is_relation_joined(ops_test, ENDPOINT, ENDPOINT) is True,
         timeout=TIMEOUT,
     )
 
@@ -428,7 +428,7 @@ async def test_restore_new_cluster(ops_test: OpsTest, continuous_writes_to_db, c
     # relate to s3 - s3 has the necessary configurations
     await ops_test.model.add_relation(S3_APP_NAME, NEW_CLUSTER)
     await ops_test.model.block_until(
-        lambda: helpers.is_relation_joined(ops_test, ENDPOINT, ENDPOINT) is True,
+        lambda: is_relation_joined(ops_test, ENDPOINT, ENDPOINT) is True,
         timeout=TIMEOUT,
     )
 

--- a/tests/integration/ha_tests/helpers.py
+++ b/tests/integration/ha_tests/helpers.py
@@ -34,9 +34,9 @@ from ..helpers import (
     get_app_name,
     get_mongo_cmd,
     get_password,
+    is_relation_joined,
     mongodb_uri,
     primary_host,
-    is_relation_joined,
 )
 
 METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())

--- a/tests/integration/ha_tests/helpers.py
+++ b/tests/integration/ha_tests/helpers.py
@@ -36,6 +36,7 @@ from ..helpers import (
     get_password,
     mongodb_uri,
     primary_host,
+    is_relation_joined,
 )
 
 METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
@@ -225,21 +226,6 @@ async def deploy_and_scale_application(ops_test: OpsTest) -> str:
         )
 
     return APPLICATION_DEFAULT_APP_NAME
-
-
-def is_relation_joined(ops_test: OpsTest, endpoint_one: str, endpoint_two: str) -> bool:
-    """Check if a relation is joined.
-
-    Args:
-        ops_test: The ops test object passed into every test case
-        endpoint_one: The first endpoint of the relation
-        endpoint_two: The second endpoint of the relation
-    """
-    for rel in ops_test.model.relations:
-        endpoints = [endpoint.name for endpoint in rel.endpoints]
-        if endpoint_one in endpoints and endpoint_two in endpoints:
-            return True
-    return False
 
 
 async def get_process_pid(

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -141,7 +141,7 @@ async def run_mongo_op(
         mongo_uri = await mongodb_uri(ops_test)
 
     if stringify:
-        mongo_cmd = f"mongosh --quiet --eval 'JSON.stringify({mongo_op})' {mongo_uri}{suffix}"
+        mongo_cmd = f"mongosh --quiet --eval 'EJSON.stringify({mongo_op})' {mongo_uri}{suffix}"
     else:
         mongo_cmd = f"mongosh --quiet --eval '{mongo_op}' {mongo_uri}{suffix}"
 

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -519,3 +519,18 @@ def audit_log_line_sanity_check(entry) -> bool:
             logger.error("Field '%s' not found in audit log entry \"%s\"", field, entry)
             return False
     return True
+
+
+def is_relation_joined(ops_test: OpsTest, endpoint_one: str, endpoint_two: str) -> bool:
+    """Check if a relation is joined.
+
+    Args:
+        ops_test: The ops test object passed into every test case
+        endpoint_one: The first endpoint of the relation
+        endpoint_two: The second endpoint of the relation
+    """
+    for rel in ops_test.model.relations:
+        endpoints = [endpoint.name for endpoint in rel.endpoints]
+        if endpoint_one in endpoints and endpoint_two in endpoints:
+            return True
+    return False

--- a/tests/integration/relation_tests/test_charm_relations.py
+++ b/tests/integration/relation_tests/test_charm_relations.py
@@ -98,40 +98,32 @@ async def verify_crud_operations(ops_test: OpsTest, connection_string: str):
 
     # query the data
     cmd = 'db.test_collection.find({}, {"release_name": 1}).toArray()'
-    result = await run_mongo_op(
-        ops_test, f"EJSON.stringify({cmd})", f'"{connection_string}"', stringify=False
-    )
+    result = await run_mongo_op(ops_test, cmd, f'"{connection_string}"', stringify=True)
     assert result.data[0]["release_name"] == "Focal Fossa"
 
     # update the data
     ubuntu_version = '{"version": "20.04"}'
     ubuntu_name_updated = '{"$set": {"release_name": "Fancy Fossa"}}'
-    cmd = f"EJSON.stringify(db.test_collection.updateOne({ubuntu_version}, {ubuntu_name_updated}))"
+    cmd = f"db.test_collection.updateOne({ubuntu_version}, {ubuntu_name_updated})"
     result = await run_mongo_op(
-        ops_test, cmd, f'"{connection_string}"', stringify=False, expect_json_load=False
+        ops_test, cmd, f'"{connection_string}"', stringify=True, expect_json_load=False
     )
     assert result.data["acknowledged"] is True
 
     # query the data
     cmd = 'db.test_collection.find({}, {"release_name": 1}).toArray()'
-    result = await run_mongo_op(
-        ops_test, f"EJSON.stringify({cmd})", f'"{connection_string}"', stringify=False
-    )
+    result = await run_mongo_op(ops_test, cmd, f'"{connection_string}"', stringify=True)
     assert len(result.data) == 1
     assert result.data[0]["release_name"] == "Fancy Fossa"
 
     # delete the data
-    cmd = 'EJSON.stringify(db.test_collection.deleteOne({"release_name": "Fancy Fossa"}))'
-    result = await run_mongo_op(
-        ops_test, cmd, f'"{connection_string}"', stringify=False, expect_json_load=False
-    )
+    cmd = 'db.test_collection.deleteOne({"release_name": "Fancy Fossa"})'
+    result = await run_mongo_op(ops_test, cmd, f'"{connection_string}"', stringify=True)
     assert result.data["acknowledged"] is True
 
     # query the data
     cmd = 'db.test_collection.find({}, {"release_name": 1}).toArray()'
-    result = await run_mongo_op(
-        ops_test, f"EJSON.stringify({cmd})", f'"{connection_string}"', stringify=False
-    )
+    result = await run_mongo_op(ops_test, cmd, f'"{connection_string}"', stringify=True)
     assert len(result.data) == 0
 
 
@@ -312,26 +304,23 @@ async def test_user_with_extra_roles(ops_test: OpsTest):
     cmd = f'db.createUser({{user: "newTestUser", pwd: "Test123", roles: [{{role: "readWrite", db: "{database}"}}]}})'
     result = await run_mongo_op(
         ops_test,
-        f'"EJSON.stringify({cmd})"',
+        cmd,
         f'"{connection_string}"',
-        stringify=False,
+        stringify=True,
         expect_json_load=False,
     )
-    cmd = "db.getUsers()"
 
+    cmd = "db.getUsers()"
     result = await run_mongo_op(
         ops_test,
-        f"EJSON.stringify({cmd})",
+        cmd,
         f'"{connection_string}"',
-        stringify=False,
-        expect_json_load=False,
+        stringify=True,
     )
-    # assert "application_first_database.newTestUser" in str(result)
     assert result.data["users"][0]["_id"] == "application_first_database.newTestUser"
+
     cmd = 'db = db.getSiblingDB("new_database"); EJSON.stringify(db.test_collection.insertOne({"test": "one"}));'
-    result = await run_mongo_op(
-        ops_test, cmd, f'"{connection_string}"', stringify=False, expect_json_load=False
-    )
+    result = await run_mongo_op(ops_test, cmd, f'"{connection_string}"', stringify=False)
     assert result.data["acknowledged"] is True
 
 

--- a/tests/integration/relation_tests/test_charm_relations.py
+++ b/tests/integration/relation_tests/test_charm_relations.py
@@ -29,6 +29,7 @@ PORT = 27017
 DATABASE_APP_NAME = "mongodb-k8s"
 FIRST_DATABASE_RELATION_NAME = "first-database"
 SECOND_DATABASE_RELATION_NAME = "second-database"
+DATABASE_RELATION_NAME = "database"
 MULTIPLE_DATABASE_CLUSTERS_RELATION_NAME = "multiple-database-clusters"
 ALIASED_MULTIPLE_DATABASE_CLUSTERS_RELATION_NAME = "aliased-multiple-database-clusters"
 ANOTHER_DATABASE_APP_NAME = "another-database"
@@ -142,7 +143,7 @@ async def test_database_relation_with_charm_libraries(ops_test: OpsTest):
         lambda: is_relation_joined(
             ops_test,
             FIRST_DATABASE_RELATION_NAME,
-            "database",
+            DATABASE_RELATION_NAME,
         )
         is True,
         timeout=600,

--- a/tests/integration/relation_tests/test_charm_relations.py
+++ b/tests/integration/relation_tests/test_charm_relations.py
@@ -13,7 +13,7 @@ from pytest_operator.plugin import OpsTest
 from tenacity import RetryError
 
 from ..ha_tests.helpers import get_replica_set_primary as replica_set_primary
-from ..helpers import check_or_scale_app, get_app_name, run_mongo_op, is_relation_joined
+from ..helpers import check_or_scale_app, get_app_name, is_relation_joined, run_mongo_op
 from .helpers import (
     get_application_relation_data,
     get_connection_string,

--- a/tests/integration/relation_tests/test_charm_relations.py
+++ b/tests/integration/relation_tests/test_charm_relations.py
@@ -91,7 +91,7 @@ async def verify_crud_operations(ops_test: OpsTest, connection_string: str):
     # insert some data
     cmd = (
         'var ubuntu = {"release_name": "Focal Fossa", "version": "20.04", "LTS": "true"}; '
-        "JSON.stringify(db.test_collection.insertOne(ubuntu));"
+        "EJSON.stringify(db.test_collection.insertOne(ubuntu), );"
     )
     result = await run_mongo_op(ops_test, cmd, f'"{connection_string}"', stringify=False)
     assert result.data["acknowledged"] is True
@@ -99,14 +99,14 @@ async def verify_crud_operations(ops_test: OpsTest, connection_string: str):
     # query the data
     cmd = 'db.test_collection.find({}, {"release_name": 1}).toArray()'
     result = await run_mongo_op(
-        ops_test, f"JSON.stringify({cmd})", f'"{connection_string}"', stringify=False
+        ops_test, f"EJSON.stringify({cmd})", f'"{connection_string}"', stringify=False
     )
     assert result.data[0]["release_name"] == "Focal Fossa"
 
     # update the data
     ubuntu_version = '{"version": "20.04"}'
     ubuntu_name_updated = '{"$set": {"release_name": "Fancy Fossa"}}'
-    cmd = f"db.test_collection.updateOne({ubuntu_version}, {ubuntu_name_updated})"
+    cmd = f"EJSON.stringify(db.test_collection.updateOne({ubuntu_version}, {ubuntu_name_updated}))"
     result = await run_mongo_op(
         ops_test, cmd, f'"{connection_string}"', stringify=False, expect_json_load=False
     )
@@ -115,13 +115,13 @@ async def verify_crud_operations(ops_test: OpsTest, connection_string: str):
     # query the data
     cmd = 'db.test_collection.find({}, {"release_name": 1}).toArray()'
     result = await run_mongo_op(
-        ops_test, f"JSON.stringify({cmd})", f'"{connection_string}"', stringify=False
+        ops_test, f"EJSON.stringify({cmd})", f'"{connection_string}"', stringify=False
     )
     assert len(result.data) == 1
     assert result.data[0]["release_name"] == "Fancy Fossa"
 
     # delete the data
-    cmd = 'db.test_collection.deleteOne({"release_name": "Fancy Fossa"})'
+    cmd = 'EJSON.stringify(db.test_collection.deleteOne({"release_name": "Fancy Fossa"}))'
     result = await run_mongo_op(
         ops_test, cmd, f'"{connection_string}"', stringify=False, expect_json_load=False
     )
@@ -130,7 +130,7 @@ async def verify_crud_operations(ops_test: OpsTest, connection_string: str):
     # query the data
     cmd = 'db.test_collection.find({}, {"release_name": 1}).toArray()'
     result = await run_mongo_op(
-        ops_test, f"JSON.stringify({cmd})", f'"{connection_string}"', stringify=False
+        ops_test, f"EJSON.stringify({cmd})", f'"{connection_string}"', stringify=False
     )
     assert len(result.data) == 0
 

--- a/tests/integration/relation_tests/test_charm_relations.py
+++ b/tests/integration/relation_tests/test_charm_relations.py
@@ -141,7 +141,7 @@ async def test_database_relation_with_charm_libraries(ops_test: OpsTest):
     await ops_test.model.block_until(
         lambda: is_relation_joined(
             ops_test,
-            f"{FIRST_DATABASE_RELATION_NAME}",
+            FIRST_DATABASE_RELATION_NAME,
             "database",
         )
         is True,

--- a/tests/integration/relation_tests/test_charm_relations.py
+++ b/tests/integration/relation_tests/test_charm_relations.py
@@ -13,7 +13,7 @@ from pytest_operator.plugin import OpsTest
 from tenacity import RetryError
 
 from ..ha_tests.helpers import get_replica_set_primary as replica_set_primary
-from ..helpers import check_or_scale_app, get_app_name, run_mongo_op
+from ..helpers import check_or_scale_app, get_app_name, run_mongo_op, is_relation_joined
 from .helpers import (
     get_application_relation_data,
     get_connection_string,
@@ -146,6 +146,15 @@ async def test_database_relation_with_charm_libraries(ops_test: OpsTest):
         f"{APPLICATION_APP_NAME}:{FIRST_DATABASE_RELATION_NAME}", db_app_name
     )
     await ops_test.model.wait_for_idle(apps=APP_NAMES, status="active")
+    await ops_test.model.block_until(
+        lambda: is_relation_joined(
+            ops_test,
+            f"{FIRST_DATABASE_RELATION_NAME}",
+            "database",
+        )
+        is True,
+        timeout=600,
+    )
 
     connection_string = await get_connection_string(
         ops_test, APPLICATION_APP_NAME, FIRST_DATABASE_RELATION_NAME

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -505,7 +505,7 @@ async def test_replication_data_consistency(ops_test: OpsTest):
     await check_if_test_documents_stored(ops_test, collection_id)
 
     # query the secondaries by targeting units
-    rs_status = await run_mongo_op(ops_test, "rs.status()")
+    rs_status = await run_mongo_op(ops_test, "JSON.stringify(rs.status())", stringify=False)
     assert rs_status.succeeded, "mongod had no response for 'rs.status()'"
 
     # get the secondaries ordered ASC by the least amount of data sync delay


### PR DESCRIPTION
 ## Issue

The new_relations test fails sometimes because it fails to get the secret.
This happens when one of the units has not received the RelationJoined event.
It ends up in [this state](https://github.com/canonical/mongodb-operator/actions/runs/10079182721/job/27871431796?pr=439#step:24:13)

## Solution

Ensuring that the message is good allows to ensure that the secret is set without modifying the test application.
This is done like it's done already in another test.

## Miscellaneous

 * Bump library version in test application
 * Add missing check when creating the operator user
 * Improve test base on json serialization


