### PR TITLE
chore: Bump all libraries to current version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ build/
 *.charm
 
 coverage*
+.coverage
 __pycache__/
 *.py[cod]
 

--- a/lib/charms/mongodb/v0/config_server_interface.py
+++ b/lib/charms/mongodb/v0/config_server_interface.py
@@ -42,7 +42,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 13
+LIBPATCH = 6
 
 
 class ClusterProvider(Object):

--- a/lib/charms/mongodb/v0/mongodb_secrets.py
+++ b/lib/charms/mongodb/v0/mongodb_secrets.py
@@ -22,7 +22,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 APP_SCOPE = Config.Relations.APP_SCOPE
 UNIT_SCOPE = Config.Relations.UNIT_SCOPE

--- a/lib/charms/mongodb/v0/set_status.py
+++ b/lib/charms/mongodb/v0/set_status.py
@@ -6,7 +6,7 @@ import json
 import logging
 from typing import Tuple
 
-from charms.mongodb.v0.mongodb import MongoDBConfiguration, MongoDBConnection
+from charms.mongodb.v1.mongodb import MongoDBConfiguration, MongoDBConnection
 from ops.charm import CharmBase
 from ops.framework import Object
 from ops.model import ActiveStatus, BlockedStatus, StatusBase, WaitingStatus
@@ -22,7 +22,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 3
+LIBPATCH = 1
 
 AUTH_FAILED_CODE = 18
 UNAUTHORISED_CODE = 13

--- a/lib/charms/mongodb/v1/helpers.py
+++ b/lib/charms/mongodb/v1/helpers.py
@@ -10,7 +10,7 @@ import string
 import subprocess
 from typing import List
 
-from charms.mongodb.v0.mongodb import MongoDBConfiguration
+from charms.mongodb.v1.mongodb import MongoDBConfiguration
 from ops.model import ActiveStatus, MaintenanceStatus, StatusBase, WaitingStatus
 
 from config import Config
@@ -23,7 +23,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 5
+LIBPATCH = 6
 
 # path to store mongodb ketFile
 KEY_FILE = "keyFile"

--- a/lib/charms/mongodb/v1/mongodb.py
+++ b/lib/charms/mongodb/v1/mongodb.py
@@ -28,11 +28,11 @@ from config import Config
 LIBID = "49c69d9977574dd7942eb7b54f43355b"
 
 # Increment this major API version when introducing breaking changes
-LIBAPI = 0
+LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 9
+LIBPATCH = 1
 
 # path to store mongodb ketFile
 logger = logging.getLogger(__name__)

--- a/lib/charms/mongodb/v1/mongodb_backups.py
+++ b/lib/charms/mongodb/v1/mongodb_backups.py
@@ -41,7 +41,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 7
+LIBPATCH = 3
 
 logger = logging.getLogger(__name__)
 

--- a/lib/charms/mongodb/v1/mongodb_provider.py
+++ b/lib/charms/mongodb/v1/mongodb_provider.py
@@ -14,8 +14,8 @@ from collections import namedtuple
 from typing import List, Optional, Set
 
 from charms.data_platform_libs.v0.data_interfaces import DatabaseProvides
-from charms.mongodb.v0.mongodb import MongoDBConfiguration, MongoDBConnection
 from charms.mongodb.v1.helpers import generate_password
+from charms.mongodb.v1.mongodb import MongoDBConfiguration, MongoDBConnection
 from ops.charm import CharmBase, EventBase, RelationBrokenEvent, RelationChangedEvent
 from ops.framework import Object
 from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, Relation
@@ -31,7 +31,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 6
+LIBPATCH = 7
 
 logger = logging.getLogger(__name__)
 REL_NAME = "database"

--- a/lib/charms/mongodb/v1/mongodb_tls.py
+++ b/lib/charms/mongodb/v1/mongodb_tls.py
@@ -34,11 +34,11 @@ Scopes = Config.Relations.Scopes
 LIBID = "e02a50f0795e4dd292f58e93b4f493dd"
 
 # Increment this major API version when introducing breaking changes
-LIBAPI = 0
+LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 15
+LIBPATCH = 1
 
 logger = logging.getLogger(__name__)
 

--- a/lib/charms/mongodb/v1/mongos.py
+++ b/lib/charms/mongodb/v1/mongos.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from typing import List, Optional, Set, Tuple
 from urllib.parse import quote_plus
 
-from charms.mongodb.v0.mongodb import NotReadyError
+from charms.mongodb.v1.mongodb import NotReadyError
 from pymongo import MongoClient, collection
 from tenacity import RetryError, Retrying, stop_after_delay, wait_fixed
 
@@ -22,7 +22,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 6
+LIBPATCH = 5
 
 # path to store mongodb ketFile
 logger = logging.getLogger(__name__)

--- a/lib/charms/mongodb/v1/shards_interface.py
+++ b/lib/charms/mongodb/v1/shards_interface.py
@@ -15,13 +15,13 @@ from charms.data_platform_libs.v0.data_interfaces import (
     DatabaseProvides,
     DatabaseRequires,
 )
-from charms.mongodb.v0.mongodb import (
+from charms.mongodb.v1.helpers import KEY_FILE
+from charms.mongodb.v1.mongodb import (
     MongoDBConnection,
     NotReadyError,
     OperationFailure,
     PyMongoError,
 )
-from charms.mongodb.v1.helpers import KEY_FILE
 from charms.mongodb.v1.mongodb_provider import LEGACY_REL_NAME, REL_NAME
 from charms.mongodb.v1.mongos import (
     BalancerNotEnabledError,
@@ -63,7 +63,8 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 16
+LIBPATCH = 7
+
 KEYFILE_KEY = "key-file"
 HOSTS_KEY = "host"
 OPERATOR_PASSWORD_KEY = MongoDBUser.get_password_key_name_for_user(OperatorUser.get_username())

--- a/lib/charms/mongodb/v1/users.py
+++ b/lib/charms/mongodb/v1/users.py
@@ -12,7 +12,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 0
+LIBPATCH = 1
 
 
 class MongoDBUser:

--- a/src/charm.py
+++ b/src/charm.py
@@ -12,13 +12,13 @@ import jinja2
 from charms.grafana_k8s.v0.grafana_dashboard import GrafanaDashboardProvider
 from charms.loki_k8s.v0.loki_push_api import LogProxyConsumer
 from charms.mongodb.v0.config_server_interface import ClusterProvider
-from charms.mongodb.v0.mongodb import (
+from charms.mongodb.v1.mongodb import (
     MongoDBConfiguration,
     MongoDBConnection,
     NotReadyError,
 )
 from charms.mongodb.v0.mongodb_secrets import SecretCache, generate_secret_label
-from charms.mongodb.v0.mongodb_tls import MongoDBTLS
+from charms.mongodb.v1.mongodb_tls import MongoDBTLS
 from charms.mongodb.v0.set_status import MongoDBStatusHandler
 from charms.mongodb.v1.helpers import (
     generate_keyfile,

--- a/src/charm.py
+++ b/src/charm.py
@@ -12,13 +12,7 @@ import jinja2
 from charms.grafana_k8s.v0.grafana_dashboard import GrafanaDashboardProvider
 from charms.loki_k8s.v0.loki_push_api import LogProxyConsumer
 from charms.mongodb.v0.config_server_interface import ClusterProvider
-from charms.mongodb.v1.mongodb import (
-    MongoDBConfiguration,
-    MongoDBConnection,
-    NotReadyError,
-)
 from charms.mongodb.v0.mongodb_secrets import SecretCache, generate_secret_label
-from charms.mongodb.v1.mongodb_tls import MongoDBTLS
 from charms.mongodb.v0.set_status import MongoDBStatusHandler
 from charms.mongodb.v1.helpers import (
     generate_keyfile,
@@ -27,8 +21,14 @@ from charms.mongodb.v1.helpers import (
     get_mongod_args,
     get_mongos_args,
 )
+from charms.mongodb.v1.mongodb import (
+    MongoDBConfiguration,
+    MongoDBConnection,
+    NotReadyError,
+)
 from charms.mongodb.v1.mongodb_backups import MongoDBBackups
 from charms.mongodb.v1.mongodb_provider import MongoDBProvider
+from charms.mongodb.v1.mongodb_tls import MongoDBTLS
 from charms.mongodb.v1.mongos import MongosConfiguration
 from charms.mongodb.v1.shards_interface import ConfigServerRequirer, ShardingProvider
 from charms.mongodb.v1.users import (

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -495,7 +495,7 @@ class TestCharm(unittest.TestCase):
 
     @patch("ops.framework.EventBase.defer")
     @patch("charm.MongoDBConnection")
-    @patch("charms.mongodb.v0.mongodb.MongoClient")
+    @patch("charms.mongodb.v1.mongodb.MongoClient")
     def test_reconfigure_get_members_failure(self, client, connection, defer):
         """Tests reconfigure does not execute when unable to get the replica set members.
 

--- a/tests/unit/test_mongodb_lib.py
+++ b/tests/unit/test_mongodb_lib.py
@@ -4,7 +4,7 @@
 import unittest
 from unittest.mock import call, patch
 
-from charms.mongodb.v0.mongodb import MongoDBConnection, NotReadyError
+from charms.mongodb.v1.mongodb import MongoDBConnection, NotReadyError
 from pymongo.errors import ConfigurationError, ConnectionFailure, OperationFailure
 from tenacity import RetryError, wait_none
 
@@ -24,9 +24,9 @@ PYMONGO_EXCEPTIONS = [
 
 
 class TestMongoServer(unittest.TestCase):
-    @patch("charms.mongodb.v0.mongodb.Retrying")
-    @patch("charms.mongodb.v0.mongodb.MongoClient")
-    @patch("charms.mongodb.v0.mongodb.MongoDBConfiguration")
+    @patch("charms.mongodb.v1.mongodb.Retrying")
+    @patch("charms.mongodb.v1.mongodb.MongoClient")
+    @patch("charms.mongodb.v1.mongodb.MongoDBConfiguration")
     def test_is_ready_error_handling(self, config, mock_client, retrying):
         """Test failure to check ready of replica returns False.
 
@@ -42,8 +42,8 @@ class TestMongoServer(unittest.TestCase):
             # verify we close connection
             (mock_client.return_value.close).assert_called()
 
-    @patch("charms.mongodb.v0.mongodb.MongoClient")
-    @patch("charms.mongodb.v0.mongodb.MongoDBConfiguration")
+    @patch("charms.mongodb.v1.mongodb.MongoClient")
+    @patch("charms.mongodb.v1.mongodb.MongoDBConfiguration")
     def test_init_replset_error_handling(self, config, mock_client):
         """Test failure to initialise replica set raises an error.
 
@@ -60,8 +60,8 @@ class TestMongoServer(unittest.TestCase):
             # verify we close connection
             (mock_client.return_value.close).assert_called()
 
-    @patch("charms.mongodb.v0.mongodb.MongoClient")
-    @patch("charms.mongodb.v0.mongodb.MongoDBConfiguration")
+    @patch("charms.mongodb.v1.mongodb.MongoClient")
+    @patch("charms.mongodb.v1.mongodb.MongoDBConfiguration")
     def test_get_replset_members_error_handling(self, config, mock_client):
         """Test failure to get replica set members raises an error.
 
@@ -76,8 +76,8 @@ class TestMongoServer(unittest.TestCase):
             # verify we close connection
             (mock_client.return_value.close).assert_called()
 
-    @patch("charms.mongodb.v0.mongodb.MongoClient")
-    @patch("charms.mongodb.v0.mongodb.MongoDBConfiguration")
+    @patch("charms.mongodb.v1.mongodb.MongoClient")
+    @patch("charms.mongodb.v1.mongodb.MongoDBConfiguration")
     def test_add_replset_members_pymongo_error_handling(self, config, mock_client):
         """Test failures related to PyMongo properly get handled in add_replset_member.
 
@@ -93,9 +93,9 @@ class TestMongoServer(unittest.TestCase):
             # verify we close connection
             (mock_client.return_value.close).assert_called()
 
-    @patch("charms.mongodb.v0.mongodb.MongoDBConnection.is_any_sync")
-    @patch("charms.mongodb.v0.mongodb.MongoClient")
-    @patch("charms.mongodb.v0.mongodb.MongoDBConfiguration")
+    @patch("charms.mongodb.v1.mongodb.MongoDBConnection.is_any_sync")
+    @patch("charms.mongodb.v1.mongodb.MongoClient")
+    @patch("charms.mongodb.v1.mongodb.MongoDBConfiguration")
     def test_add_replset_member_wait_to_sync(self, config, mock_client, any_sync):
         """Tests that adding replica set members raises NotReadyError if another member is syncing.
 
@@ -114,8 +114,8 @@ class TestMongoServer(unittest.TestCase):
         no_reconfig = call("replSetReconfig") not in actual_calls
         self.assertEqual(no_reconfig, True)
 
-    @patch("charms.mongodb.v0.mongodb.MongoClient")
-    @patch("charms.mongodb.v0.mongodb.MongoDBConfiguration")
+    @patch("charms.mongodb.v1.mongodb.MongoClient")
+    @patch("charms.mongodb.v1.mongodb.MongoDBConfiguration")
     def test_remove_replset_members_pymongo_error_handling(self, config, mock_client):
         """Test failures related to PyMongo properly get handled in remove_replset_member.
 
@@ -132,9 +132,9 @@ class TestMongoServer(unittest.TestCase):
             # verify we close connection
             (mock_client.return_value.close).assert_called()
 
-    @patch("charms.mongodb.v0.mongodb.MongoDBConnection._is_any_removing")
-    @patch("charms.mongodb.v0.mongodb.MongoClient")
-    @patch("charms.mongodb.v0.mongodb.MongoDBConfiguration")
+    @patch("charms.mongodb.v1.mongodb.MongoDBConnection._is_any_removing")
+    @patch("charms.mongodb.v1.mongodb.MongoClient")
+    @patch("charms.mongodb.v1.mongodb.MongoDBConfiguration")
     def test_remove_replset_member_wait_to_remove(self, config, mock_client, any_remove):
         """Tests removing replica set members raises NotReadyError if another member is removing.
 
@@ -154,9 +154,9 @@ class TestMongoServer(unittest.TestCase):
         no_reconfig = call("replSetReconfig") not in actual_calls
         self.assertEqual(no_reconfig, True)
 
-    @patch("charms.mongodb.v0.mongodb.MongoDBConnection._is_any_removing")
-    @patch("charms.mongodb.v0.mongodb.MongoClient")
-    @patch("charms.mongodb.v0.mongodb.MongoDBConfiguration")
+    @patch("charms.mongodb.v1.mongodb.MongoDBConnection._is_any_removing")
+    @patch("charms.mongodb.v1.mongodb.MongoClient")
+    @patch("charms.mongodb.v1.mongodb.MongoDBConfiguration")
     def test_create_user_error_handling(self, config, mock_client, any_remove):
         """Test failures related to PyMongo properly get handled when creating a user.
 
@@ -171,8 +171,8 @@ class TestMongoServer(unittest.TestCase):
             # verify we close connection
             (mock_client.return_value.close).assert_called()
 
-    @patch("charms.mongodb.v0.mongodb.MongoClient")
-    @patch("charms.mongodb.v0.mongodb.MongoDBConfiguration")
+    @patch("charms.mongodb.v1.mongodb.MongoClient")
+    @patch("charms.mongodb.v1.mongodb.MongoDBConfiguration")
     def test_update_user_error_handling(self, config, mock_client):
         """Test failures related to PyMongo properly get handled when updating a user.
 
@@ -187,8 +187,8 @@ class TestMongoServer(unittest.TestCase):
             # verify we close connection
             (mock_client.return_value.close).assert_called()
 
-    @patch("charms.mongodb.v0.mongodb.MongoClient")
-    @patch("charms.mongodb.v0.mongodb.MongoDBConfiguration")
+    @patch("charms.mongodb.v1.mongodb.MongoClient")
+    @patch("charms.mongodb.v1.mongodb.MongoDBConfiguration")
     def test_drop_user_error_handling(self, config, mock_client):
         """Test failures related to PyMongo properly get handled when dropping a user.
 


### PR DESCRIPTION
Following https://github.com/canonical/mongodb-operator/pull/437