### PR TITLE
Fix log rotation

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -272,8 +272,6 @@ class MongoDBCharm(CharmBase):
                 max_log_size=Config.LogRotate.MAX_LOG_SIZE,
                 max_rotations=Config.LogRotate.MAX_ROTATIONS_TO_KEEP,
             ),
-            user=Config.UNIX_USER,
-            group=Config.UNIX_GROUP,
         )
 
         layer_config = {
@@ -546,6 +544,8 @@ class MongoDBCharm(CharmBase):
         container.add_layer("log_rotate", self._log_rotate_layer, combine=True)
         if self.is_role(Config.Role.CONFIG_SERVER):
             container.add_layer("mongos", self._mongos_layer, combine=True)
+
+        container.exec(["chmod", "644", "/etc/logrotate.d/mongodb"])
 
         # Restart changed services and start startup-enabled services.
         container.replan()

--- a/templates/logrotate.j2
+++ b/templates/logrotate.j2
@@ -1,16 +1,17 @@
 {{logs_directory}}/*.log
 {
-  rotate {{max_rotations}}
-  size {{max_log_size}}
-  missingok
-  notifempty
-  create 0600 {{mongo_user}} {{mongo_user}}
-  compress
-  nomail
-  nocopytruncate
-  sharedscripts
-  postrotate
-    /bin/kill -SIGUSR1 $(pgrep -f "mongod.*--logpath=*")
-  endscript
+    rotate {{max_rotations}}
+    size {{max_log_size}}
+    missingok
+    notifempty
+    create 0600 {{mongo_user}} {{mongo_user}}
+    compress
+    delaycompress
+    nomail
+    nocopytruncate
+    sharedscripts
+    postrotate
+        PID=$(pgrep -f "mongod.*--logpath={{logs_directory}}/mongodb.log")
+        /bin/kill -SIGUSR1 $PID
+    endscript
 }
-

--- a/templates/logrotate.j2
+++ b/templates/logrotate.j2
@@ -10,9 +10,7 @@
   nocopytruncate
   sharedscripts
   postrotate
-    {% for id in service_ids %}
-         pebble restart mongod_{{ id }}
-    {% endfor %}
+    /bin/kill -SIGUSR1 $(pgrep -f "mongod.*--logpath=*")
   endscript
 }
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -191,6 +191,18 @@ async def test_log_rotate(ops_test: OpsTest) -> None:
         audit_log_exists = "audit.log" in log_files
         assert audit_log_exists, f"Could not find audit.log log in {log_files}"
 
+        # wait for some logs to be collected
+        time.sleep(10)
+
+        audit_log_content = subprocess.check_output(
+            f"JUJU_MODEL={ops_test.model_full_name} juju ssh  --container mongod {unit.name}  'cat {audit_log_path}.audit.log'",
+            stderr=subprocess.PIPE,
+            shell=True,
+            universal_newlines=True,
+        )
+        audit_log_lines = audit_log_content.strip().split("\n")
+        assert len(audit_log_lines) > 0, "New audit logs have not been written after log rotation."
+
 
 @pytest.mark.group(1)
 async def test_monitor_user(ops_test: OpsTest) -> None:

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -195,7 +195,7 @@ async def test_log_rotate(ops_test: OpsTest) -> None:
         time.sleep(10)
 
         audit_log_content = subprocess.check_output(
-            f"JUJU_MODEL={ops_test.model_full_name} juju ssh  --container mongod {unit.name}  'cat {audit_log_path}.audit.log'",
+            f"JUJU_MODEL={ops_test.model_full_name} juju ssh  --container mongod {unit.name}  'cat {audit_log_path}audit.log'",
             stderr=subprocess.PIPE,
             shell=True,
             universal_newlines=True,

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -185,7 +185,7 @@ async def test_log_rotate(ops_test: OpsTest) -> None:
             universal_newlines=True,
         )
 
-        log_rotated = "audit.log.1.gz" in log_files
+        log_rotated = "audit.log.1" in log_files
         assert log_rotated, f"Could not find rotated log in {log_files}"
 
         audit_log_exists = "audit.log" in log_files

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -102,6 +102,7 @@ class TestCharm(unittest.TestCase):
         container = self.harness.model.unit.get_container("mongod")
         self.harness.set_can_connect(container, True)
         container.make_dir("/etc/logrotate.d", make_parents=True)
+        container.exec = mock.Mock()
         # Emit the PebbleReadyEvent carrying the mongod container
         self.harness.charm.on.mongod_pebble_ready.emit(container)
         # Get the plan now we've run PebbleReady
@@ -928,6 +929,7 @@ class TestCharm(unittest.TestCase):
         """Tests the _connect_mongodb_exporter method has been called."""
         container = self.harness.model.unit.get_container("mongod")
         self.harness.set_can_connect(container, True)
+        container.exec = mock.Mock()
         container.make_dir("/etc/logrotate.d", make_parents=True)
 
         self.harness.set_can_connect(container, True)


### PR DESCRIPTION
## Issue:
After rotating audit logs, the new `audit.log` file remains empty.
This suggests mongodb may not resignal logrotate to open the log file.

## Solution:
Fix post rotate script