### PR TITLE
[DPE-5098] Tests for mongos / mongodb integration

### DIFF
--- a/tests/integration/ha_tests/helpers.py
+++ b/tests/integration/ha_tests/helpers.py
@@ -376,10 +376,12 @@ async def fetch_replica_set_members(
 
 async def get_direct_mongo_client(
     ops_test: OpsTest,
-    unit: str = None,
+    unit: str | None = None,
     excluded: List[str] = [],
-    app_name: str = None,
-    use_subprocess_to_get_password=False,
+    app_name: str | None = None,
+    username: str = "operator",
+    password: str | None = None,
+    use_subprocess_to_get_password: bool = False,
     mongos: bool = False,
 ) -> MongoClient:
     """Returns a direct mongodb client potentially passing over some of the units."""
@@ -390,6 +392,8 @@ async def get_direct_mongo_client(
             [int(unit.split("/")[1])],
             use_subprocess_to_get_password=use_subprocess_to_get_password,
             port=port,
+            username=username,
+            password=password,
         )
         return MongoClient(url, directConnection=True)
 
@@ -403,6 +407,8 @@ async def get_direct_mongo_client(
                 use_subprocess_to_get_password=use_subprocess_to_get_password,
                 app_name=mongodb_name,
                 port=port,
+                username=username,
+                password=password,
             )
             return MongoClient(url, directConnection=True)
     assert False, "No fitting unit could be found"

--- a/tests/integration/sharding_tests/helpers.py
+++ b/tests/integration/sharding_tests/helpers.py
@@ -30,7 +30,7 @@ def count_users(mongos_client: MongoClient) -> int:
 async def get_related_username_password(
     ops_test: OpsTest, app_name: str, relation_name: str
 ) -> Tuple:
-    """Retrieves the username and password for an integrated application using app_name and relation_name"""
+    """Retrieves the credentials for an integrated application using app_name and relation_name."""
     secret_uri = await get_application_relation_data(
         ops_test, app_name, relation_name, "secret-user"
     )

--- a/tests/integration/sharding_tests/helpers.py
+++ b/tests/integration/sharding_tests/helpers.py
@@ -27,7 +27,9 @@ def count_users(mongos_client: MongoClient) -> int:
     return users_collection.count_documents({})
 
 
-async def get_username_password(ops_test: OpsTest, app_name: str, relation_name: str) -> Tuple:
+async def get_related_username_password(
+    ops_test: OpsTest, app_name: str, relation_name: str
+) -> Tuple:
     secret_uri = await get_application_relation_data(
         ops_test, app_name, relation_name, "secret-user"
     )

--- a/tests/integration/sharding_tests/helpers.py
+++ b/tests/integration/sharding_tests/helpers.py
@@ -2,17 +2,11 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 from typing import List, Optional, Tuple
-from urllib.parse import quote_plus
 
 from pymongo import MongoClient
 from pytest_operator.plugin import OpsTest
 
-from ..helpers import (
-    METADATA,
-    get_application_relation_data,
-    get_password,
-    get_secret_content,
-)
+from ..helpers import METADATA, get_application_relation_data, get_secret_content
 
 SHARD_ONE_APP_NAME = "shard-one"
 SHARD_TWO_APP_NAME = "shard-two"
@@ -24,37 +18,6 @@ CLUSTER_COMPONENTS = [SHARD_ONE_APP_NAME, SHARD_TWO_APP_NAME, CONFIG_SERVER_APP_
 TIMEOUT = 15 * 60
 MONGOS_PORT = 27018
 MONGOD_PORT = 27017
-
-
-async def generate_mongodb_client(
-    ops_test: OpsTest,
-    app_name: str,
-    mongos: bool,
-    username: str = "operator",
-    password: str = None,
-):
-    """Returns a MongoDB client for mongos/mongod."""
-
-    status = await ops_test.model.get_status()
-
-    hosts = [
-        status["applications"][app_name]["units"][unit.name]["address"]
-        for unit in ops_test.model.applications[app_name].units
-    ]
-    password = password or await get_password(ops_test, app_name=app_name)
-    username = username
-    port = MONGOS_PORT if mongos else MONGOD_PORT
-    hosts = [f"{host}:{port}" for host in hosts]
-    hosts = ",".join(hosts)
-    auth_source = ""
-    database = "admin"
-
-    return MongoClient(
-        f"mongodb://{username}:"
-        f"{quote_plus(password)}@"
-        f"{hosts}/{quote_plus(database)}?"
-        f"{auth_source}"
-    )
 
 
 def count_users(mongos_client: MongoClient) -> int:

--- a/tests/integration/sharding_tests/helpers.py
+++ b/tests/integration/sharding_tests/helpers.py
@@ -30,6 +30,7 @@ def count_users(mongos_client: MongoClient) -> int:
 async def get_related_username_password(
     ops_test: OpsTest, app_name: str, relation_name: str
 ) -> Tuple:
+    """Retrieves the username and password for an integrated application using app_name and relation_name"""
     secret_uri = await get_application_relation_data(
         ops_test, app_name, relation_name, "secret-user"
     )

--- a/tests/integration/sharding_tests/test_mongos.py
+++ b/tests/integration/sharding_tests/test_mongos.py
@@ -8,7 +8,7 @@ from pymongo.errors import OperationFailure
 from pytest_operator.plugin import OpsTest
 
 from ..ha_tests.helpers import get_direct_mongo_client
-from .helpers import count_users, get_username_password
+from .helpers import count_users, get_related_username_password
 
 SHARD_ONE_APP_NAME = "shard-one"
 MONGOS_APP_NAME = "mongos-k8s"
@@ -90,7 +90,7 @@ async def test_connect_to_cluster_creates_user(ops_test: OpsTest) -> None:
         num_users_after_integration == num_users + 1
     ), "Cluster did not create new users after integration."
 
-    (username, password) = await get_username_password(
+    (username, password) = await get_related_username_password(
         ops_test, app_name=MONGOS_APP_NAME, relation_name=CLUSTER_REL_NAME
     )
     mongos_user_client = await get_direct_mongo_client(
@@ -110,7 +110,7 @@ async def test_connect_to_cluster_creates_user(ops_test: OpsTest) -> None:
 async def test_disconnect_from_cluster_removes_user(ops_test: OpsTest) -> None:
     """Verifies that when the cluster is formed a the user is removed."""
     # generate URI for new mongos user
-    (username, password) = await get_username_password(
+    (username, password) = await get_related_username_password(
         ops_test, app_name=MONGOS_APP_NAME, relation_name=CLUSTER_REL_NAME
     )
     mongos_user_client = await get_direct_mongo_client(

--- a/tests/integration/sharding_tests/test_mongos.py
+++ b/tests/integration/sharding_tests/test_mongos.py
@@ -18,7 +18,6 @@ CONFIG_SERVER_REL_NAME = "config-server"
 TIMEOUT = 10 * 60
 
 
-@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])
 @pytest.mark.group(1)
 @pytest.mark.skip("Will be enabled after DPE-5040 is done")
 @pytest.mark.abort_on_fail
@@ -50,7 +49,6 @@ async def test_build_and_deploy(ops_test: OpsTest, mongos_host_application_charm
     )
 
 
-@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])
 @pytest.mark.group(1)
 @pytest.mark.skip("Will be enabled after DPE-5040 is done")
 @pytest.mark.abort_on_fail
@@ -106,7 +104,6 @@ async def test_connect_to_cluster_creates_user(ops_test: OpsTest) -> None:
     mongos_user_client.admin.command("dbStats")
 
 
-@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])
 @pytest.mark.group(1)
 @pytest.mark.skip("Will be enabled after DPE-5040 is done")
 @pytest.mark.abort_on_fail

--- a/tests/integration/sharding_tests/test_mongos.py
+++ b/tests/integration/sharding_tests/test_mongos.py
@@ -53,19 +53,19 @@ async def test_build_and_deploy(ops_test: OpsTest) -> None:
 @pytest.mark.skip("Will be enabled after DPE-5040 is done")
 @pytest.mark.abort_on_fail
 async def test_connect_to_cluster_creates_user(ops_test: OpsTest) -> None:
-    #    """Verifies that when the cluster is formed a new user is created."""
-    #    await ops_test.model.integrate(
-    #        f"{SHARD_ONE_APP_NAME}:{SHARD_REL_NAME}",
-    #        f"{CONFIG_SERVER_APP_NAME}:{CONFIG_SERVER_REL_NAME}",
-    #    )
-    #
-    #    await ops_test.model.wait_for_idle(
-    #        apps=[MONGOS_APP_NAME, SHARD_ONE_APP_NAME, CONFIG_SERVER_APP_NAME],
-    #        idle_period=20,
-    #        raise_on_blocked=False,
-    #        timeout=TIMEOUT,
-    #        raise_on_error=False,
-    #    )
+    """Verifies that when the cluster is formed a new user is created."""
+    await ops_test.model.integrate(
+        f"{SHARD_ONE_APP_NAME}:{SHARD_REL_NAME}",
+        f"{CONFIG_SERVER_APP_NAME}:{CONFIG_SERVER_REL_NAME}",
+    )
+
+    await ops_test.model.wait_for_idle(
+        apps=[MONGOS_APP_NAME, SHARD_ONE_APP_NAME, CONFIG_SERVER_APP_NAME],
+        idle_period=20,
+        raise_on_blocked=False,
+        timeout=TIMEOUT,
+        raise_on_error=False,
+    )
 
     mongos_client = await get_direct_mongo_client(
         ops_test, app_name=CONFIG_SERVER_APP_NAME, mongos=True

--- a/tests/integration/sharding_tests/test_mongos.py
+++ b/tests/integration/sharding_tests/test_mongos.py
@@ -37,7 +37,6 @@ async def test_build_and_deploy(ops_test: OpsTest, mongos_host_application_charm
     await ops_test.model.deploy(
         MONGOS_APP_NAME,
         channel="6/edge",
-        revision=3,
     )
 
     await ops_test.model.wait_for_idle(
@@ -45,7 +44,7 @@ async def test_build_and_deploy(ops_test: OpsTest, mongos_host_application_charm
         idle_period=20,
         raise_on_blocked=False,  # cluster components are blocked waiting for integration.
         timeout=TIMEOUT,
-        raise_on_error=False,
+        raise_on_error=False,  # Remove this once DPE-4996 is resovled
     )
 
 
@@ -87,7 +86,7 @@ async def test_connect_to_cluster_creates_user(ops_test: OpsTest) -> None:
     num_users_after_integration = count_users(mongos_client)
 
     assert (
-        num_users_after_integration > num_users
+        num_users_after_integration == num_users + 1
     ), "Cluster did not create new users after integration."
 
     (username, password) = await get_username_password(
@@ -139,7 +138,7 @@ async def test_disconnect_from_cluster_removes_user(ops_test: OpsTest) -> None:
     num_users_after_removal = count_users(mongos_client)
 
     assert (
-        num_users > num_users_after_removal
+        num_users - 1 == num_users_after_removal
     ), "Cluster did not remove user after integration removal."
 
     with pytest.raises(OperationFailure) as pymongo_error:

--- a/tests/integration/sharding_tests/test_mongos.py
+++ b/tests/integration/sharding_tests/test_mongos.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+
+import pytest
+from pymongo.errors import OperationFailure
+from pytest_operator.plugin import OpsTest
+
+from .helpers import count_users, generate_mongodb_client, get_username_password
+
+SHARD_ONE_APP_NAME = "shard-one"
+MONGOS_APP_NAME = "mongos-k8s"
+CONFIG_SERVER_APP_NAME = "config-server-one"
+SHARD_REL_NAME = "sharding"
+CLUSTER_REL_NAME = "cluster"
+CONFIG_SERVER_REL_NAME = "config-server"
+TIMEOUT = 10 * 60
+
+
+@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])
+@pytest.mark.group(1)
+@pytest.mark.skip("Will be enabled after DPE-5040 is done")
+@pytest.mark.abort_on_fail
+async def test_build_and_deploy(ops_test: OpsTest, mongos_host_application_charm) -> None:
+    """Build and deploy a sharded cluster."""
+    mongodb_charm = await ops_test.build_charm(".")
+    await ops_test.model.deploy(
+        mongodb_charm,
+        num_units=1,
+        config={"role": "config-server"},
+        application_name=CONFIG_SERVER_APP_NAME,
+    )
+    await ops_test.model.deploy(
+        mongodb_charm, num_units=1, config={"role": "shard"}, application_name=SHARD_ONE_APP_NAME
+    )
+
+    await ops_test.model.deploy(
+        MONGOS_APP_NAME,
+        channel="6/edge",
+        revision=3,
+    )
+
+    await ops_test.model.wait_for_idle(
+        apps=[CONFIG_SERVER_APP_NAME, SHARD_ONE_APP_NAME],
+        idle_period=20,
+        raise_on_blocked=False,  # cluster components are blocked waiting for integration.
+        timeout=TIMEOUT,
+        raise_on_error=False,
+    )
+
+
+@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])
+@pytest.mark.group(1)
+@pytest.mark.skip("Will be enabled after DPE-5040 is done")
+@pytest.mark.abort_on_fail
+async def test_connect_to_cluster_creates_user(ops_test: OpsTest) -> None:
+    """Verifies that when the cluster is formed a new user is created."""
+    await ops_test.model.integrate(
+        f"{SHARD_ONE_APP_NAME}:{SHARD_REL_NAME}",
+        f"{CONFIG_SERVER_APP_NAME}:{CONFIG_SERVER_REL_NAME}",
+    )
+
+    await ops_test.model.wait_for_idle(
+        apps=[MONGOS_APP_NAME, SHARD_ONE_APP_NAME, CONFIG_SERVER_APP_NAME],
+        idle_period=20,
+        raise_on_blocked=False,
+        timeout=TIMEOUT,
+        raise_on_error=False,
+    )
+
+    mongos_client = await generate_mongodb_client(
+        ops_test, app_name=CONFIG_SERVER_APP_NAME, mongos=True
+    )
+    num_users = count_users(mongos_client)
+
+    await ops_test.model.integrate(
+        f"{MONGOS_APP_NAME}",
+        f"{CONFIG_SERVER_APP_NAME}",
+    )
+
+    await ops_test.model.wait_for_idle(
+        apps=[CONFIG_SERVER_APP_NAME, SHARD_ONE_APP_NAME, MONGOS_APP_NAME],
+        idle_period=20,
+        timeout=TIMEOUT,
+        raise_on_error=False,
+    )
+
+    num_users_after_integration = count_users(mongos_client)
+
+    assert (
+        num_users_after_integration > num_users
+    ), "Cluster did not create new users after integration."
+
+    (username, password) = await get_username_password(
+        ops_test, app_name=MONGOS_APP_NAME, relation_name=CLUSTER_REL_NAME
+    )
+    mongos_user_client = await generate_mongodb_client(
+        ops_test,
+        app_name=CONFIG_SERVER_APP_NAME,
+        mongos=True,
+        username=username,
+        password=password,
+    )
+
+    mongos_user_client.admin.command("dbStats")
+
+
+@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])
+@pytest.mark.group(1)
+@pytest.mark.skip("Will be enabled after DPE-5040 is done")
+@pytest.mark.abort_on_fail
+async def test_disconnect_from_cluster_removes_user(ops_test: OpsTest) -> None:
+    """Verifies that when the cluster is formed a the user is removed."""
+    # generate URI for new mongos user
+    (username, password) = await get_username_password(
+        ops_test, app_name=MONGOS_APP_NAME, relation_name=CLUSTER_REL_NAME
+    )
+    mongos_user_client = await generate_mongodb_client(
+        ops_test,
+        app_name=CONFIG_SERVER_APP_NAME,
+        mongos=True,
+        username=username,
+        password=password,
+    )
+
+    # generate URI for operator mongos user (i.e. admin)
+    mongos_client = await generate_mongodb_client(
+        ops_test, app_name=CONFIG_SERVER_APP_NAME, mongos=True
+    )
+    num_users = count_users(mongos_client)
+    await ops_test.model.applications[MONGOS_APP_NAME].remove_relation(
+        f"{MONGOS_APP_NAME}:cluster",
+        f"{CONFIG_SERVER_APP_NAME}:cluster",
+    )
+    await ops_test.model.wait_for_idle(
+        apps=[CONFIG_SERVER_APP_NAME, MONGOS_APP_NAME],
+        idle_period=20,
+        timeout=TIMEOUT,
+        raise_on_error=False,
+    )
+    num_users_after_removal = count_users(mongos_client)
+
+    assert (
+        num_users > num_users_after_removal
+    ), "Cluster did not remove user after integration removal."
+
+    with pytest.raises(OperationFailure) as pymongo_error:
+        mongos_user_client.admin.command("dbStats")
+
+    assert pymongo_error.value.code == 18, "User still exists after relation was removed."

--- a/tests/integration/sharding_tests/test_sharding_relations.py
+++ b/tests/integration/sharding_tests/test_sharding_relations.py
@@ -24,7 +24,6 @@ DATABASE_REL_NAME = "first-database"
 LEGACY_RELATION_NAME = "obsolete"
 
 
-@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
 async def test_build_and_deploy(ops_test: OpsTest) -> None:
@@ -64,7 +63,6 @@ async def test_build_and_deploy(ops_test: OpsTest) -> None:
     )
 
 
-@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
 async def test_shard_s3_relation(ops_test: OpsTest) -> None:

--- a/tests/integration/tls_tests/helpers.py
+++ b/tests/integration/tls_tests/helpers.py
@@ -78,7 +78,7 @@ async def run_tls_check(
     ops_test: OpsTest, unit: ops.model.Unit, app_name: str | None = None, mongos: bool = False
 ) -> int:
     """Returns the return code of the TLS check."""
-    app_name = app_name or get_app_name(ops_test)
+    app_name = app_name or await get_app_name(ops_test)
     port = "27017" if not mongos else "27018"
     hosts = [
         f"{parse_hostname(unit.name, app_name)}:{port}"


### PR DESCRIPTION
## Description

This PR adds the test in mongodb-k8s to check for the validity and stability of the integration between the newly developed mongos-k8s charm which handles the connection with outside applications, and the sharded deployment (on mongodb-k8s side).

## What it does:
 * Integrate tests for mongos / mongodb integration in k8s

## How it has been checked:
 * Tests are green with manual deployment (waiting for [PR 20](https://github.com/canonical/mongos-k8s-operator/pull/20) to be merged to enable it fully)
 
## Instructions for manual check:

* Build local charms
```
juju add-model integ-test

cd <mongodb-k8s-operator>
git checkout DPE-5098-mongo-db-k-8-s-tests-add-config-server-mongos-integration-tests
tox -e build-production
juju deploy ./*charm --config role="shard" shard-one -n1  --resource mongodb-image=ghcr.io/canonical/charmed-mongodb:6.0.6-22.04_edge@sha256:b4b3edb805b20de471da57802643bfadbf979f112d738bc540ab148d145ddcfe
juju deploy ./*charm --config role="config-server" config-server-one -n1  --resource mongodb-image=ghcr.io/canonical/charmed-mongodb:6.0.6-22.04_edge@sha256:b4b3edb805b20de471da57802643bfadbf979f112d738bc540ab148d145ddcfe

cd <mongos-k8s-operator
git checkout DPE-5040-mongos-config-svr
tox -e build-production
juju deploy ./*charm --resource mongodb-image=ghcr.io/canonical/charmed-mongodb:6.0.6-22.04_edge@sha256:b4b3edb805b20de471da57802643bfadbf979f112d738bc540ab148d145ddcfe

cd <mongodb-k8s-operator>
tox -e integration -- tests/integration/sharding_tests/test_mongos.py  --model=integ-test
```

## Miscellaneous

 * Small fix in tls tests, a call was never awaited