### PR TITLE
fix: upstream-source cannot have both tag and sha

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -61,7 +61,7 @@ resources:
     type: oci-image
     description: OCI image for mongodb
     # TODO: Update sha whenever upstream rock changes
-    upstream-source: ghcr.io/canonical/charmed-mongodb:6.0.6-22.04_edge@sha256:b4b3edb805b20de471da57802643bfadbf979f112d738bc540ab148d145ddcfe
+    upstream-source: ghcr.io/canonical/charmed-mongodb@sha256:b4b3edb805b20de471da57802643bfadbf979f112d738bc540ab148d145ddcfe
 storage:
   mongodb:
     type: filesystem


### PR DESCRIPTION
## Problem

* image is not uploaded because of `upstream-source` has both tag and sha256 which is not supported.
* Regression introduced in https://github.com/canonical/mongodb-k8s-operator/commit/4a1cbba3e07bddce5c72e57bf60bcb62f6aa0a3d

## Solution

* Remove tag as we rather use the sha256 here