### PR TITLE
test(mongos): Re-enable Mongos charm tests

### DIFF
--- a/tests/integration/sharding_tests/test_mongos.py
+++ b/tests/integration/sharding_tests/test_mongos.py
@@ -7,9 +7,8 @@ import pytest
 from pymongo.errors import OperationFailure
 from pytest_operator.plugin import OpsTest
 
-from tests.integration.helpers import METADATA
-
 from ..ha_tests.helpers import get_direct_mongo_client
+from ..helpers import METADATA
 from .helpers import count_users, get_related_username_password
 
 SHARD_ONE_APP_NAME = "shard-one"

--- a/tests/integration/sharding_tests/test_mongos.py
+++ b/tests/integration/sharding_tests/test_mongos.py
@@ -7,6 +7,8 @@ import pytest
 from pymongo.errors import OperationFailure
 from pytest_operator.plugin import OpsTest
 
+from tests.integration.helpers import METADATA
+
 from ..ha_tests.helpers import get_direct_mongo_client
 from .helpers import count_users, get_related_username_password
 
@@ -24,14 +26,20 @@ TIMEOUT = 10 * 60
 async def test_build_and_deploy(ops_test: OpsTest) -> None:
     """Build and deploy a sharded cluster."""
     mongodb_charm = await ops_test.build_charm(".")
+    resources = {"mongodb-image": METADATA["resources"]["mongodb-image"]["upstream-source"]}
     await ops_test.model.deploy(
         mongodb_charm,
+        resources=resources,
         num_units=1,
         config={"role": "config-server"},
         application_name=CONFIG_SERVER_APP_NAME,
     )
     await ops_test.model.deploy(
-        mongodb_charm, num_units=1, config={"role": "shard"}, application_name=SHARD_ONE_APP_NAME
+        mongodb_charm,
+        reousrces=resources,
+        num_units=1,
+        config={"role": "shard"},
+        application_name=SHARD_ONE_APP_NAME,
     )
 
     await ops_test.model.deploy(

--- a/tests/integration/sharding_tests/test_mongos.py
+++ b/tests/integration/sharding_tests/test_mongos.py
@@ -35,7 +35,7 @@ async def test_build_and_deploy(ops_test: OpsTest) -> None:
     )
     await ops_test.model.deploy(
         mongodb_charm,
-        reousrces=resources,
+        resources=resources,
         num_units=1,
         config={"role": "shard"},
         application_name=SHARD_ONE_APP_NAME,

--- a/tests/integration/sharding_tests/test_mongos.py
+++ b/tests/integration/sharding_tests/test_mongos.py
@@ -20,7 +20,6 @@ TIMEOUT = 10 * 60
 
 
 @pytest.mark.group(1)
-@pytest.mark.skip("Will be enabled after DPE-5040 is done")
 @pytest.mark.abort_on_fail
 async def test_build_and_deploy(ops_test: OpsTest) -> None:
     """Build and deploy a sharded cluster."""
@@ -50,7 +49,6 @@ async def test_build_and_deploy(ops_test: OpsTest) -> None:
 
 
 @pytest.mark.group(1)
-@pytest.mark.skip("Will be enabled after DPE-5040 is done")
 @pytest.mark.abort_on_fail
 async def test_connect_to_cluster_creates_user(ops_test: OpsTest) -> None:
     """Verifies that when the cluster is formed a new user is created."""
@@ -105,7 +103,6 @@ async def test_connect_to_cluster_creates_user(ops_test: OpsTest) -> None:
 
 
 @pytest.mark.group(1)
-@pytest.mark.skip("Will be enabled after DPE-5040 is done")
 @pytest.mark.abort_on_fail
 async def test_disconnect_from_cluster_removes_user(ops_test: OpsTest) -> None:
     """Verifies that when the cluster is formed a the user is removed."""


### PR DESCRIPTION
 * Some tests were disabled because of DPE-5040
 * Now that https://github.com/canonical/mongos-k8s-operator/pull/20 is merged, it can be re enabled.