### PR TITLE
[DPE-5215] Upgrade libraries to fix secret disclosure issue

### DIFF
--- a/tests/integration/sharding_tests/test_mongos.py
+++ b/tests/integration/sharding_tests/test_mongos.py
@@ -94,7 +94,7 @@ async def test_connect_to_cluster_creates_user(ops_test: OpsTest) -> None:
         lambda: is_relation_joined(
             ops_test,
             CLUSTER_REL_NAME,
-            CONFIG_SERVER_REL_NAME,
+            CLUSTER_REL_NAME,
         )
         is True,
         timeout=600,


### PR DESCRIPTION
## Problem

* We were using the `DatabaseProvider` class wrong
* This lead to a secret disclosure issue with mongo-k8s

## Solution

* The library was fixed in https://github.com/canonical/mongodb-operator/pull/472
* Bump here + small fixes

## Miscellaneous

* Fix `db_initialised` property