### PR TITLE
[DPE-5318] update user management

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -595,7 +595,7 @@ class MongoDBCharm(CharmBase):
             return
 
         logger.error(
-            f"cluster migration currently not supported, cannot change from { self.model.config['role']} to {self.role}"
+            f"cluster migration currently not supported, cannot change from {self.model.config['role']} to {self.role}"
         )
         raise ShardingMigrationError(
             f"Migration of sharding components not permitted, revert config role to {self.role}"

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1,5 +1,6 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
+import json
 import logging
 import re
 import unittest
@@ -329,9 +330,8 @@ class TestCharm(unittest.TestCase):
         mock_container.return_value.can_connect.return_value = True
         mock_container.return_value.exists.return_value = True
         self.harness.charm.unit.get_container = mock_container
-
-        self.harness.charm.app_peer_data["replica_set_initialised"] = "True"
-        self.harness.charm.app_peer_data["users_initialized"] = "True"
+        self.harness.charm.app_peer_data["replica_set_initialised"] = json.dumps(True)
+        self.harness.charm.app_peer_data["users_initialized"] = json.dumps(True)
 
         self.harness.charm.on.start.emit()
 
@@ -524,7 +524,7 @@ class TestCharm(unittest.TestCase):
         """
         # presets
         self.harness.set_leader(True)
-        self.harness.charm.app_peer_data["db_initialised"] = "True"
+        self.harness.charm.app_peer_data["db_initialised"] = json.dumps(True)
         rel = self.harness.charm.model.get_relation("database-peers")
 
         for exception, _ in PYMONGO_EXCEPTIONS:
@@ -559,7 +559,7 @@ class TestCharm(unittest.TestCase):
         """
         # presets
         self.harness.set_leader(True)
-        self.harness.charm.app_peer_data["db_initialised"] = "True"
+        self.harness.charm.app_peer_data["db_initialised"] = json.dumps(True)
         connection.return_value.__enter__.return_value.get_replset_members.return_value = {
             "mongodb-k8s-0.mongodb-k8s-endpoints",
             "mongodb-k8s-1.mongodb-k8s-endpoints",
@@ -593,7 +593,7 @@ class TestCharm(unittest.TestCase):
         """
         # presets
         self.harness.set_leader(True)
-        self.harness.charm.app_peer_data["db_initialised"] = "True"
+        self.harness.charm.app_peer_data["db_initialised"] = json.dumps(True)
         connection.return_value.__enter__.return_value.get_replset_members.return_value = {
             "mongodb-k8s-0.mongodb-k8s-endpoints"
         }
@@ -617,7 +617,7 @@ class TestCharm(unittest.TestCase):
         """
         # presets
         self.harness.set_leader(True)
-        self.harness.charm.app_peer_data["db_initialised"] = "True"
+        self.harness.charm.app_peer_data["db_initialised"] = json.dumps(True)
         connection.return_value.__enter__.return_value.get_replset_members.return_value = {
             "mongodb-k8s-0.mongodb-k8s-endpoints"
         }
@@ -662,7 +662,7 @@ class TestCharm(unittest.TestCase):
 
         oversee_users.side_effect = PyMongoError()
 
-        self.harness.charm.app_peer_data["replica_set_initialised"] = "True"
+        self.harness.charm.app_peer_data["replica_set_initialised"] = json.dumps(True)
         self.harness.charm.on.start.emit()
         self.assertEqual("operator-user-created" in self.harness.charm.app_peer_data, True)
         defer.assert_called()
@@ -957,7 +957,7 @@ class TestCharm(unittest.TestCase):
         container.make_dir("/etc/logrotate.d", make_parents=True)
 
         self.harness.set_can_connect(container, True)
-        self.harness.charm.app_peer_data["db_initialised"] = "True"
+        self.harness.charm.app_peer_data["db_initialised"] = json.dumps(True)
         self.harness.charm.on.mongod_pebble_ready.emit(container)
 
         password = self.harness.charm.get_secret("app", "monitor-password")
@@ -1022,7 +1022,7 @@ class TestCharm(unittest.TestCase):
         """Tests what backup user was created."""
         self.harness.charm._initialise_users.retry.wait = wait_none()
         container = self.harness.model.unit.get_container("mongod")
-        self.harness.charm.app_peer_data["replica_set_initialised"] = "True"
+        self.harness.charm.app_peer_data["replica_set_initialised"] = json.dumps(True)
         self.harness.set_can_connect(container, True)
         self.harness.charm.on.start.emit()
         password = self.harness.charm.get_secret("app", "backup-password")

--- a/tests/unit/test_mongodb_backups.py
+++ b/tests/unit/test_mongodb_backups.py
@@ -1,5 +1,6 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
+import json
 import unittest
 from unittest import mock
 from unittest.mock import patch
@@ -277,7 +278,7 @@ class TestMongoBackups(unittest.TestCase):
         service.return_value = "pbm"
 
         _set_config_options.side_effect = SetPBMConfigError
-        self.harness.charm.app_peer_data["db_initialised"] = "True"
+        self.harness.charm.app_peer_data["db_initialised"] = json.dumps(True)
 
         # triggering s3 event with correct fields
         mock_s3_info = mock.Mock()
@@ -305,7 +306,7 @@ class TestMongoBackups(unittest.TestCase):
         """Test charm defers when more time is needed to sync pbm."""
         container = self.harness.model.unit.get_container("mongod")
         self.harness.set_can_connect(container, True)
-        self.harness.charm.app_peer_data["db_initialised"] = "True"
+        self.harness.charm.app_peer_data["db_initialised"] = json.dumps(True)
         service.return_value = "pbm"
         pbm_status.return_value = ActiveStatus()
         resync.side_effect = SetPBMConfigError
@@ -333,7 +334,7 @@ class TestMongoBackups(unittest.TestCase):
         """Test charm defers when more time is needed to sync pbm credentials."""
         container = self.harness.model.unit.get_container("mongod")
         self.harness.set_can_connect(container, True)
-        self.harness.charm.app_peer_data["db_initialised"] = "True"
+        self.harness.charm.app_peer_data["db_initialised"] = json.dumps(True)
         service.return_value = "pbm"
         resync.side_effect = ResyncError
 
@@ -364,7 +365,7 @@ class TestMongoBackups(unittest.TestCase):
         """Test charm defers when more time is needed to sync pbm."""
         container = self.harness.model.unit.get_container("mongod")
         self.harness.set_can_connect(container, True)
-        self.harness.charm.app_peer_data["db_initialised"] = "True"
+        self.harness.charm.app_peer_data["db_initialised"] = json.dumps(True)
         service.return_value = "pbm"
 
         resync.side_effect = PBMBusyError
@@ -397,7 +398,7 @@ class TestMongoBackups(unittest.TestCase):
         container = self.harness.model.unit.get_container("mongod")
         self.harness.set_can_connect(container, True)
         service.return_value = "pbm"
-        self.harness.charm.app_peer_data["db_initialised"] = "True"
+        self.harness.charm.app_peer_data["db_initialised"] = json.dumps(True)
         resync.side_effect = ExecError(
             command=["/usr/bin/pbm status"], exit_code=1, stdout="status code: 403", stderr=""
         )


### PR DESCRIPTION
## Issue:

1. Users created by clients get automatically deleted by MongoDB charm
2. Users for mongos K8s charm get automatically deleted by MongoDB charm

## Solution:

Keep track of which users the charm should manage and only remove/update those users by bringing over k8s lib

## Testing

Lib tested for all charms that use it i.e. MongoDB VM+K8s and Mongos K8s