### PR TITLE
tests: remove unnecessary patching of private ops class

### DIFF
--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -3,27 +3,7 @@
 # See LICENSE file for licensing details.
 
 from pathlib import Path
-from typing import Callable
-from unittest.mock import patch
 
 import yaml
 
 METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
-
-
-def patch_network_get(private_address="10.1.157.116") -> Callable:
-    def network_get(*args, **kwargs) -> dict:
-        """Patch for the not-yet-implemented testing backend needed for `bind_address`.
-
-        This patch decorator can be used for cases such as:
-        self.model.get_binding(event.relation).network.bind_address
-        """
-        return {
-            "bind-addresses": [
-                {
-                    "addresses": [{"value": private_address}],
-                }
-            ]
-        }
-
-    return patch("ops.testing._TestingModelBackend.network_get", network_get)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -23,8 +23,6 @@ from tenacity import stop_after_attempt, wait_fixed, wait_none
 
 from charm import MongoDBCharm, NotReadyError
 
-from .helpers import patch_network_get
-
 PYMONGO_EXCEPTIONS = [
     (ConnectionFailure("error message"), ConnectionFailure),
     (ConfigurationError("error message"), ConfigurationError),
@@ -36,7 +34,6 @@ logger = logging.getLogger(__name__)
 
 
 class TestCharm(unittest.TestCase):
-    @patch_network_get(private_address="1.1.1.1")
     def setUp(self):
         self.maxDiff = None
         self.harness = Harness(MongoDBCharm)
@@ -1044,7 +1041,6 @@ class TestCharm(unittest.TestCase):
         # verify app data is updated and results are reported to user
         self.assertEqual("canonical123", new_password)
 
-    @patch_network_get(private_address="1.1.1.1")
     @patch("charm.MongoDBCharm.has_backup_service")
     @patch("charm.MongoDBBackups.get_pbm_status")
     def test_set_backup_password_pbm_busy(self, pbm_status, has_backup_service):

--- a/tests/unit/test_mongodb_backups.py
+++ b/tests/unit/test_mongodb_backups.py
@@ -25,13 +25,10 @@ from ops.testing import Harness
 
 from charm import MongoDBCharm
 
-from .helpers import patch_network_get
-
 RELATION_NAME = "s3-credentials"
 
 
 class TestMongoBackups(unittest.TestCase):
-    @patch_network_get(private_address="1.1.1.1")
     def setUp(self):
         self.harness = Harness(MongoDBCharm)
         self.harness.begin()
@@ -268,7 +265,6 @@ class TestMongoBackups(unittest.TestCase):
 
         defer.assert_called()
 
-    @patch_network_get(private_address="1.1.1.1")
     @patch("charm.MongoDBCharm.has_backup_service")
     @patch("charm.MongoDBBackups._set_config_options")
     def test_s3_credentials_set_pbm_failure(self, _set_config_options, service):
@@ -294,7 +290,6 @@ class TestMongoBackups(unittest.TestCase):
 
         self.assertTrue(isinstance(self.harness.charm.unit.status, BlockedStatus))
 
-    @patch_network_get(private_address="1.1.1.1")
     @patch("charm.MongoDBBackups._set_config_options")
     @patch("charm.MongoDBBackups._resync_config_options")
     @patch("ops.framework.EventBase.defer")
@@ -324,7 +319,6 @@ class TestMongoBackups(unittest.TestCase):
         )
         self.assertTrue(isinstance(self.harness.charm.unit.status, BlockedStatus))
 
-    @patch_network_get(private_address="1.1.1.1")
     @patch("charm.MongoDBBackups._set_config_options")
     @patch("charm.MongoDBBackups._resync_config_options")
     @patch("ops.framework.EventBase.defer")
@@ -353,7 +347,6 @@ class TestMongoBackups(unittest.TestCase):
         defer.assert_called()
         self.assertTrue(isinstance(self.harness.charm.unit.status, WaitingStatus))
 
-    @patch_network_get(private_address="1.1.1.1")
     @patch("charm.MongoDBBackups._set_config_options")
     @patch("charm.MongoDBBackups._resync_config_options")
     @patch("ops.framework.EventBase.defer")
@@ -385,7 +378,6 @@ class TestMongoBackups(unittest.TestCase):
         defer.assert_called()
         self.assertTrue(isinstance(self.harness.charm.unit.status, WaitingStatus))
 
-    @patch_network_get(private_address="1.1.1.1")
     @patch("charm.MongoDBBackups._set_config_options")
     @patch("charm.MongoDBBackups._resync_config_options")
     @patch("ops.framework.EventBase.defer")

--- a/tests/unit/test_mongodb_provider.py
+++ b/tests/unit/test_mongodb_provider.py
@@ -12,8 +12,6 @@ from pymongo.errors import ConfigurationError, ConnectionFailure, OperationFailu
 
 from charm import MongoDBCharm
 
-from .helpers import patch_network_get
-
 PYMONGO_EXCEPTIONS = [
     (ConnectionFailure("error message"), ConnectionFailure),
     (ConfigurationError("error message"), ConfigurationError),
@@ -25,7 +23,6 @@ DEPARTED_IDS = [None, 0]
 
 
 class TestMongoProvider(unittest.TestCase):
-    @patch_network_get(private_address="1.1.1.1")
     def setUp(self):
         self.harness = Harness(MongoDBCharm)
         mongo_resource = {
@@ -61,7 +58,6 @@ class TestMongoProvider(unittest.TestCase):
         oversee_users.assert_not_called()
         defer.assert_not_called()
 
-    @patch_network_get(private_address="1.1.1.1")
     @patch("ops.framework.EventBase.defer")
     @patch("charm.MongoDBProvider.oversee_users")
     def test_relation_event_oversee_users_mongo_failure(self, oversee_users, defer):
@@ -85,7 +81,6 @@ class TestMongoProvider(unittest.TestCase):
             defer.assert_called()
 
     # oversee_users raises AssertionError when unable to attain users from relation
-    @patch_network_get(private_address="1.1.1.1")
     @patch("ops.framework.EventBase.defer")
     @patch("charm.MongoDBProvider.oversee_users")
     def test_relation_event_oversee_users_fails_to_get_relation(self, oversee_users, defer):
@@ -107,7 +102,6 @@ class TestMongoProvider(unittest.TestCase):
                 else:
                     self.harness.remove_relation_unit(relation_id, "consumer/0")
 
-    @patch_network_get(private_address="1.1.1.1")
     @patch("charms.mongodb.v1.mongodb_provider.MongoConnection")
     def test_oversee_users_get_users_failure(self, connection):
         """Verifies that when unable to retrieve users from mongod an exception is raised."""
@@ -119,7 +113,6 @@ class TestMongoProvider(unittest.TestCase):
                         dep_id, RelationEvent(mock.Mock(), mock.Mock())
                     )
 
-    @patch_network_get(private_address="1.1.1.1")
     @patch("charm.MongoDBProvider._get_users_from_relations")
     @patch("charms.mongodb.v1.mongodb_provider.MongoConnection")
     def test_oversee_users_drop_user_failure(self, connection, relation_users):
@@ -141,7 +134,6 @@ class TestMongoProvider(unittest.TestCase):
                         dep_id, RelationEvent(mock.Mock(), mock.Mock())
                     )
 
-    @patch_network_get(private_address="1.1.1.1")
     @patch("charm.MongoDBProvider._get_users_from_relations")
     @patch("charms.mongodb.v1.mongodb_provider.MongoConnection")
     def test_oversee_users_get_config_failure(self, connection, relation_users):
@@ -158,7 +150,6 @@ class TestMongoProvider(unittest.TestCase):
                     dep_id, RelationEvent(mock.Mock(), mock.Mock())
                 )
 
-    @patch_network_get(private_address="1.1.1.1")
     @patch("charm.MongoDBProvider._set_relation")
     @patch("charm.MongoDBProvider._get_config")
     @patch("charm.MongoDBProvider._get_users_from_relations")
@@ -181,7 +172,6 @@ class TestMongoProvider(unittest.TestCase):
             connection.return_value.__enter__.return_value.create_user.assert_not_called()
             set_relation.assert_not_called()
 
-    @patch_network_get(private_address="1.1.1.1")
     @patch("charm.MongoDBProvider._set_relation")
     @patch("charm.MongoDBProvider._get_config")
     @patch("charm.MongoDBProvider._get_users_from_relations")
@@ -203,7 +193,6 @@ class TestMongoProvider(unittest.TestCase):
                     )
                 set_relation.assert_not_called()
 
-    @patch_network_get(private_address="1.1.1.1")
     @patch("charm.MongoDBProvider._get_config")
     @patch("charm.MongoDBProvider._get_users_from_relations")
     @patch("charms.mongodb.v1.mongodb_provider.MongoConnection")
@@ -223,7 +212,6 @@ class TestMongoProvider(unittest.TestCase):
                     dep_id, RelationEvent(mock.Mock(), mock.Mock())
                 )
 
-    @patch_network_get(private_address="1.1.1.1")
     @patch("charm.MongoDBProvider._get_users_from_relations")
     @patch("charms.mongodb.v1.mongodb_provider.MongoConnection")
     def test_oversee_users_update_get_config_failure(self, connection, relation_users):
@@ -240,7 +228,6 @@ class TestMongoProvider(unittest.TestCase):
                     dep_id, RelationEvent(mock.Mock(), mock.Mock())
                 )
 
-    @patch_network_get(private_address="1.1.1.1")
     @patch("charm.MongoDBProvider._get_config")
     @patch("charm.MongoDBProvider._get_users_from_relations")
     @patch("charms.mongodb.v1.mongodb_provider.MongoConnection")
@@ -260,7 +247,6 @@ class TestMongoProvider(unittest.TestCase):
                         dep_id, RelationEvent(mock.Mock(), mock.Mock())
                     )
 
-    @patch_network_get(private_address="1.1.1.1")
     @patch("charm.MongoDBProvider._get_databases_from_relations")
     @patch("charm.MongoDBProvider._get_users_from_relations")
     @patch("charms.mongodb.v1.mongodb_provider.MongoConnection")
@@ -278,7 +264,6 @@ class TestMongoProvider(unittest.TestCase):
             )
             connection.return_value.__enter__.return_value.drop_database.assert_not_called()
 
-    @patch_network_get(private_address="1.1.1.1")
     @patch("charm.MongoDBProvider._get_users_from_relations")
     @patch("charms.mongodb.v1.mongodb_provider.MongoConnection")
     def test_oversee_users_mongo_databases_failure(self, connection, relation_users):
@@ -295,7 +280,6 @@ class TestMongoProvider(unittest.TestCase):
                         dep_id, RelationEvent(mock.Mock(), mock.Mock())
                     )
 
-    @patch_network_get(private_address="1.1.1.1")
     @patch("charm.MongoDBProvider._get_databases_from_relations")
     @patch("charm.MongoDBProvider._get_users_from_relations")
     @patch("charms.mongodb.v1.mongodb_provider.MongoConnection")


### PR DESCRIPTION
The tests currently patch `ops.testing._TestingModelBackend`, which is a private class. This will break in an upcoming release of ops.

The patching is actually not required any more, so can just be entirely removed rather than updated.