### PR TITLE
fix: Only update databag is not shard

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -744,7 +744,8 @@ class MongoDBCharm(CharmBase):
                 self._add_units_from_replica_set(event, mongo, mongodb_hosts - replset_members)
 
                 # app relations should be made aware of the new set of hosts
-                self.client_relations.update_app_relation_data()
+                if not self.is_role(Config.Role.SHARD):
+                    self.client_relations.update_app_relation_data()
 
             except NotReadyError:
                 self.status.set_and_share_status(
@@ -1574,8 +1575,8 @@ class MongoDBCharm(CharmBase):
             )
             logger.error(
                 "Charm is in sharding role: %s. Does not support %s interface.",
-                rel_interface,
                 self.role,
+                rel_interface,
             )
             return False
 


### PR DESCRIPTION
## Issue

During an update-status event, the shard status would show an incorrect status "Charm is in sharding role: database. Does not support shard interface".

## Solution

This is due to the newly added checks a few weeks ago on the update relation app databag. Fixed by running this handler only if we're not a shard.
Also, the log line was incorrect, two arguments were swapped.