### PR TITLE
feat: Mutating webhook

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -59,7 +59,7 @@ containers:
     mounts:
       - storage: mongodb
         location: /var/lib/mongodb
-  data-platform-k8s-webhook-mutator:
+  webhook-mutator:
     resource: data-platform-k8s-webhook-mutator-image
 resources:
   mongodb-image:
@@ -71,7 +71,7 @@ resources:
     type: oci-image
     description: OCI image for mongodb
     # TODO: Update sha whenever upstream rock changes
-    upstream-source: ghcr.io/canonical/data-platform-k8s-webhook-mutator@sha256:c1eeac37e90e81b63fa9d9cd6b3c654ba51db611fef7045eccbb6cec27585b3d
+    upstream-source: ghcr.io/canonical/data-platform-k8s-webhook-mutator@sha256:6b161078854208e92b0827a910fe29fddb00138d17ede144970a671a9dee0c95
 storage:
   mongodb:
     type: filesystem

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -71,7 +71,7 @@ resources:
     type: oci-image
     description: OCI image for mongodb
     # TODO: Update sha whenever upstream rock changes
-    upstream-source: ghcr.io/canonical/data-platform-k8s-webhook-mutator@sha256:6b161078854208e92b0827a910fe29fddb00138d17ede144970a671a9dee0c95
+    upstream-source: ghcr.io/canonical/data-platform-k8s-mutator@sha256:6b161078854208e92b0827a910fe29fddb00138d17ede144970a671a9dee0c95
 storage:
   mongodb:
     type: filesystem

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -71,7 +71,7 @@ resources:
     type: oci-image
     description: OCI image for mongodb
     # TODO: Update sha whenever upstream rock changes
-    upstream-source: ghcr.io/canonical/data-platform-k8s-mutator@sha256:6b161078854208e92b0827a910fe29fddb00138d17ede144970a671a9dee0c95
+    upstream-source: ghcr.io/canonical/data-platform-k8s-mutator@sha256:bd10e490771c9124b7daaecfb95cfae3a9f45a77af8c94de70556cfaaffd8a4a
 storage:
   mongodb:
     type: filesystem

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -60,8 +60,7 @@ containers:
       - storage: mongodb
         location: /var/lib/mongodb
   data-platform-k8s-webhook-mutator:
-    mongod:
-      resource: data-platform-k8s-webhook-mutator-image
+    resource: data-platform-k8s-webhook-mutator-image
 resources:
   mongodb-image:
     type: oci-image
@@ -72,7 +71,7 @@ resources:
     type: oci-image
     description: OCI image for mongodb
     # TODO: Update sha whenever upstream rock changes
-    upstream-source: <todo add this when we publish>
+    upstream-source: ghcr.io/canonical/data-platform-k8s-webhook-mutator@sha256:c1eeac37e90e81b63fa9d9cd6b3c654ba51db611fef7045eccbb6cec27585b3d
 storage:
   mongodb:
     type: filesystem

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -59,12 +59,20 @@ containers:
     mounts:
       - storage: mongodb
         location: /var/lib/mongodb
+  data-platform-k8s-webhook-mutator:
+    mongod:
+      resource: data-platform-k8s-webhook-mutator-image
 resources:
   mongodb-image:
     type: oci-image
     description: OCI image for mongodb
     # TODO: Update sha whenever upstream rock changes
     upstream-source: ghcr.io/canonical/charmed-mongodb@sha256:b4b3edb805b20de471da57802643bfadbf979f112d738bc540ab148d145ddcfe
+  data-platform-k8s-webhook-mutator-image:
+    type: oci-image
+    description: OCI image for mongodb
+    # TODO: Update sha whenever upstream rock changes
+    upstream-source: <todo add this when we publish>
 storage:
   mongodb:
     type: filesystem

--- a/src/config.py
+++ b/src/config.py
@@ -162,6 +162,8 @@ class Config:
         PORT = 8000
         CRT_PATH = "/app/certificate.crt"
         KEY_PATH = "/app/certificate.key"
+        CRT_SECRET = "webhook-certificate"
+        KEY_SECRET = "webhook-key"
 
     @staticmethod
     def get_license_path(license_name: str) -> str:

--- a/src/config.py
+++ b/src/config.py
@@ -153,6 +153,13 @@ class Config:
         )
         WAITING_POST_UPGRADE_STATUS = WaitingStatus("Waiting for post upgrade checks")
 
+    class WebhookManager:
+        """Webhook Manager related constants."""
+
+        CONTAINER_NAME = "webhook-mutator"
+        SERVICE_NAME = "fastapi"
+        GRACE_PERIOD_SECONDS = 31_556_952  # one year
+
     @staticmethod
     def get_license_path(license_name: str) -> str:
         """Return the path to the license file."""

--- a/src/config.py
+++ b/src/config.py
@@ -159,6 +159,9 @@ class Config:
         CONTAINER_NAME = "webhook-mutator"
         SERVICE_NAME = "fastapi"
         GRACE_PERIOD_SECONDS = 31_556_952  # one year
+        PORT = 8000
+        CRT_PATH = "/app/certificate.crt"
+        KEY_PATH = "/app/certificate.key"
 
     @staticmethod
     def get_license_path(license_name: str) -> str:

--- a/src/gen_cert.py
+++ b/src/gen_cert.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Generates a self signed certificate for the mutating webhook."""
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+import datetime
+
+from cryptography import x509
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import NameOID
+
+
+def gen_certificate(app_name: str, ns: str) -> tuple[bytes, bytes]:
+    """Generates a tuple of cert and key for the mutating webhook."""
+    one_day = datetime.timedelta(1, 0, 0)
+    private_key = rsa.generate_private_key(
+        public_exponent=65537, key_size=2048, backend=default_backend()
+    )
+    public_key = private_key.public_key()
+
+    builder = x509.CertificateBuilder()
+    builder = builder.subject_name(x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, app_name)]))
+    builder = builder.issuer_name(x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, ns)]))
+    builder = builder.not_valid_before(datetime.datetime.today() - one_day)
+    builder = builder.not_valid_after(datetime.datetime.today() + (one_day * 365 * 100))
+    builder = builder.serial_number(x509.random_serial_number())
+    builder = builder.public_key(public_key)
+    builder = builder.add_extension(
+        x509.SubjectAlternativeName(
+            [
+                x509.DNSName(f"{app_name}.{ns}.svc"),
+            ]
+        ),
+        critical=False,
+    )
+    builder = builder.add_extension(
+        x509.BasicConstraints(ca=False, path_length=None), critical=True
+    )
+
+    certificate = builder.sign(
+        private_key=private_key, algorithm=hashes.SHA256(), backend=default_backend()
+    )
+
+    return (
+        certificate.public_bytes(serialization.Encoding.PEM),
+        private_key.private_bytes(
+            serialization.Encoding.PEM,
+            serialization.PrivateFormat.PKCS8,
+            serialization.NoEncryption(),
+        ),
+    )

--- a/src/service_manager.py
+++ b/src/service_manager.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Handles kubernetes services and webhook creation."""
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+import base64
+from logging import getLogger
+
+from lightkube import Client
+from lightkube.core.exceptions import ApiError
+from lightkube.models.admissionregistration_v1 import (
+    MutatingWebhook,
+    RuleWithOperations,
+    ServiceReference,
+    WebhookClientConfig,
+)
+from lightkube.models.core_v1 import ServicePort, ServiceSpec
+from lightkube.models.meta_v1 import ObjectMeta, OwnerReference
+from lightkube.resources.admissionregistration_v1 import MutatingWebhookConfiguration
+from lightkube.resources.core_v1 import Pod, Service
+from ops.model import Unit
+
+from config import Config
+
+logger = getLogger()
+
+
+def get_pod(client: Client, pod_name: str) -> Pod:
+    """Gets a pod definition from k8s."""
+    try:
+        pod = client.get(res=Pod, name=pod_name)
+    except ApiError:
+        raise
+    return pod
+
+
+def generate_service(client: Client, unit: Unit, model_name: str):
+    """Generates the k8s service for the mutating webhook."""
+    pod_name = unit.name.replace("/", "-")
+    pod = get_pod(client, pod_name)
+    if not pod.metadata:
+        raise Exception(f"Could not find metadata for {pod}")
+
+    try:
+        service = Service(
+            metadata=ObjectMeta(
+                name=Config.WebhookManager.SERVICE_NAME,
+                namespace=model_name,
+                ownerReferences=[
+                    OwnerReference(
+                        apiVersion=pod.apiVersion,
+                        kind=pod.kind,
+                        name=pod_name,
+                        uid=pod.metadata.uid,
+                        blockOwnerDeletion=False,
+                    )
+                ],
+            ),
+            spec=ServiceSpec(
+                type="ClusterIP",
+                selector={"statefulset.kubernetes.io/pod-name": pod_name},
+                ports=[
+                    ServicePort(
+                        protocol="TCP",
+                        port=Config.WebhookManager.PORT,
+                        targetPort=Config.WebhookManager.PORT,
+                        name=f"{Config.WebhookManager.SERVICE_NAME}-port",
+                    ),
+                ],
+            ),
+        )
+        client.create(service)
+    except ApiError:
+        logger.info("Not creating a service, already present")
+
+
+def generate_mutating_webhook(client: Client, unit: Unit, model_name: str, cert: str):
+    """Generates the mutating webhook for this application."""
+    pod_name = unit.name.replace("/", "-")
+    pod = get_pod(client, pod_name)
+    app_name = unit.name.split("/")[0]
+    try:
+        webhooks = client.get(
+            MutatingWebhookConfiguration,
+            namespace=model_name,
+            name=Config.WebhookManager.SERVICE_NAME,
+        )
+        if webhooks:
+            return
+    except ApiError:
+        logger.debug("Mutating Webhook doesn't yet exist.")
+
+    ca_bundle = base64.b64encode(cert.encode()).decode()
+
+    logger.debug("Registering our Mutating Wehook.")
+    webhook_config = MutatingWebhookConfiguration(
+        metadata=ObjectMeta(
+            name=Config.WebhookManager.SERVICE_NAME,
+            namespace=model_name,
+            ownerReferences=pod.metadata.ownerReferences,
+        ),
+        apiVersion="admissionregistration.k8s.io/v1",
+        webhooks=[
+            MutatingWebhook(
+                name=f"{app_name}.juju.is",
+                clientConfig=WebhookClientConfig(
+                    service=ServiceReference(
+                        namespace=model_name,
+                        name=Config.WebhookManager.SERVICE_NAME,
+                        port=8000,
+                        path="/mutate",
+                    ),
+                    caBundle=ca_bundle,
+                ),
+                rules=[
+                    RuleWithOperations(
+                        operations=["CREATE", "UPDATE"],
+                        apiGroups=["apps"],
+                        apiVersions=["v1"],
+                        resources=["statefulsets"],
+                    )
+                ],
+                admissionReviewVersions=["v1"],
+                sideEffects="None",
+                timeoutSeconds=5,
+            )
+        ],
+    )
+    client.create(webhook_config)

--- a/src/service_manager.py
+++ b/src/service_manager.py
@@ -23,6 +23,8 @@ from config import Config
 
 logger = getLogger()
 
+SERVICE_NAME = f"{Config.WebhookManager.SERVICE_NAME}-{Config.WebhookManager.CONTAINER_NAME}"
+
 
 def get_pod(client: Client, pod_name: str) -> Pod:
     """Gets a pod definition from k8s."""
@@ -43,7 +45,7 @@ def generate_service(client: Client, unit: Unit, model_name: str):
     try:
         service = Service(
             metadata=ObjectMeta(
-                name=Config.WebhookManager.SERVICE_NAME,
+                name=SERVICE_NAME,
                 namespace=model_name,
                 ownerReferences=[
                     OwnerReference(
@@ -63,7 +65,7 @@ def generate_service(client: Client, unit: Unit, model_name: str):
                         protocol="TCP",
                         port=Config.WebhookManager.PORT,
                         targetPort=Config.WebhookManager.PORT,
-                        name=f"{Config.WebhookManager.SERVICE_NAME}-port",
+                        name=f"{SERVICE_NAME}-port",
                     ),
                 ],
             ),
@@ -82,7 +84,7 @@ def generate_mutating_webhook(client: Client, unit: Unit, model_name: str, cert:
         webhooks = client.get(
             MutatingWebhookConfiguration,
             namespace=model_name,
-            name=Config.WebhookManager.SERVICE_NAME,
+            name=SERVICE_NAME,
         )
         if webhooks:
             return
@@ -94,7 +96,7 @@ def generate_mutating_webhook(client: Client, unit: Unit, model_name: str, cert:
     logger.debug("Registering our Mutating Wehook.")
     webhook_config = MutatingWebhookConfiguration(
         metadata=ObjectMeta(
-            name=Config.WebhookManager.SERVICE_NAME,
+            name=SERVICE_NAME,
             namespace=model_name,
             ownerReferences=pod.metadata.ownerReferences,
         ),
@@ -105,7 +107,7 @@ def generate_mutating_webhook(client: Client, unit: Unit, model_name: str, cert:
                 clientConfig=WebhookClientConfig(
                     service=ServiceReference(
                         namespace=model_name,
-                        name=Config.WebhookManager.SERVICE_NAME,
+                        name=SERVICE_NAME,
                         port=8000,
                         path="/mutate",
                     ),

--- a/tests/integration/backup_tests/test_backups.py
+++ b/tests/integration/backup_tests/test_backups.py
@@ -6,16 +6,16 @@ import logging
 import secrets
 import string
 import time
-from pathlib import Path
 
 import pytest
 import pytest_asyncio
-import yaml
 from pytest_operator.plugin import OpsTest
 from tenacity import RetryError, Retrying, stop_after_delay, wait_fixed
 
 from ..ha_tests import helpers as ha_helpers
 from ..helpers import (
+    METADATA,
+    RESOURCES,
     check_or_scale_app,
     destroy_cluster,
     get_app_name,
@@ -29,7 +29,6 @@ S3_APP_NAME = "s3-integrator"
 TIMEOUT = 15 * 60
 ENDPOINT = "s3-credentials"
 NEW_CLUSTER = "new-mongodb"
-METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 DATABASE_APP_NAME = METADATA["name"]
 NUM_UNITS = 3
 
@@ -99,13 +98,10 @@ async def test_build_and_deploy(ops_test: OpsTest) -> None:
     else:
         async with ops_test.fast_forward():
             my_charm = await ops_test.build_charm(".")
-            resources = {
-                "mongodb-image": METADATA["resources"]["mongodb-image"]["upstream-source"]
-            }
             await ops_test.model.deploy(
                 my_charm,
                 num_units=NUM_UNITS,
-                resources=resources,
+                resources=RESOURCES,
                 series="jammy",
                 trust=True,
             )
@@ -406,13 +402,18 @@ async def test_restore_new_cluster(
 
     # deploy a new cluster with a different name
     db_charm = await ops_test.build_charm(".")
-    resources = {"mongodb-image": METADATA["resources"]["mongodb-image"]["upstream-source"]}
     await ops_test.model.deploy(
+<<<<<<< HEAD
         db_charm,
         num_units=3,
         resources=resources,
         application_name=new_cluster_app_name,
         trust=True,
+||||||| parent of 0ded9b66 (wip: test part)
+        db_charm, num_units=3, resources=resources, application_name=new_cluster_app_name
+=======
+        db_charm, num_units=3, resources=RESOURCES, application_name=new_cluster_app_name
+>>>>>>> 0ded9b66 (wip: test part)
     )
 
     await asyncio.gather(

--- a/tests/integration/backup_tests/test_backups.py
+++ b/tests/integration/backup_tests/test_backups.py
@@ -403,17 +403,11 @@ async def test_restore_new_cluster(
     # deploy a new cluster with a different name
     db_charm = await ops_test.build_charm(".")
     await ops_test.model.deploy(
-<<<<<<< HEAD
         db_charm,
         num_units=3,
-        resources=resources,
+        resources=RESOURCES,
         application_name=new_cluster_app_name,
         trust=True,
-||||||| parent of 0ded9b66 (wip: test part)
-        db_charm, num_units=3, resources=resources, application_name=new_cluster_app_name
-=======
-        db_charm, num_units=3, resources=RESOURCES, application_name=new_cluster_app_name
->>>>>>> 0ded9b66 (wip: test part)
     )
 
     await asyncio.gather(

--- a/tests/integration/backup_tests/test_sharding_backups.py
+++ b/tests/integration/backup_tests/test_sharding_backups.py
@@ -14,8 +14,8 @@ from tenacity import Retrying, stop_after_delay, wait_fixed
 from ..backup_tests import helpers as backup_helpers
 from ..ha_tests.helpers import deploy_and_scale_application, get_direct_mongo_client
 from ..helpers import (
-    METADATA,
     MONGOS_PORT,
+    RESOURCES,
     get_leader_id,
     get_password,
     mongodb_uri,
@@ -299,7 +299,6 @@ async def deploy_cluster_backup_test(
     ops_test: OpsTest, deploy_s3_integrator=True, new_names=False
 ) -> None:
     """Deploy a cluster for the backup test."""
-    resources = {"mongodb-image": METADATA["resources"]["mongodb-image"]["upstream-source"]}
     my_charm = await ops_test.build_charm(".")
 
     config_server_name = CONFIG_SERVER_APP_NAME if not new_names else CONFIG_SERVER_APP_NAME_NEW
@@ -307,7 +306,7 @@ async def deploy_cluster_backup_test(
     shard_two_name = SHARD_TWO_APP_NAME if not new_names else SHARD_TWO_APP_NAME_NEW
     await ops_test.model.deploy(
         my_charm,
-        resources=resources,
+        resources=RESOURCES,
         num_units=2,
         config={"role": "config-server"},
         application_name=config_server_name,
@@ -315,7 +314,7 @@ async def deploy_cluster_backup_test(
     )
     await ops_test.model.deploy(
         my_charm,
-        resources=resources,
+        resources=RESOURCES,
         num_units=2,
         config={"role": "shard"},
         application_name=shard_one_name,
@@ -323,7 +322,7 @@ async def deploy_cluster_backup_test(
     )
     await ops_test.model.deploy(
         my_charm,
-        resources=resources,
+        resources=RESOURCES,
         num_units=1,
         config={"role": "shard"},
         application_name=shard_two_name,

--- a/tests/integration/ha_tests/helpers.py
+++ b/tests/integration/ha_tests/helpers.py
@@ -16,7 +16,6 @@ from typing import Dict, List, Optional
 
 import kubernetes as kubernetes
 import ops
-import yaml
 from juju.unit import Unit
 from pymongo import MongoClient
 from pytest_operator.plugin import OpsTest
@@ -33,6 +32,7 @@ from ..helpers import (
     APP_NAME,
     MONGOD_PORT,
     MONGOS_PORT,
+    RESOURCES,
     get_app_name,
     get_mongo_cmd,
     get_password,
@@ -41,7 +41,6 @@ from ..helpers import (
     primary_host,
 )
 
-METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 MONGODB_CONTAINER_NAME = "mongod"
 MONGODB_SERVICE_NAME = "mongod"
 MONGOD_PROCESS_NAME = "mongod"
@@ -175,13 +174,11 @@ async def deploy_and_scale_mongodb(
         # Cache the built charm to avoid rebuilding it between tests
         mongodb_charm = charm
 
-    resources = {"mongodb-image": METADATA["resources"]["mongodb-image"]["upstream-source"]}
-
     async with ops_test.fast_forward():
         await ops_test.model.deploy(
             mongodb_charm,
             application_name=mongodb_application_name,
-            resources=resources,
+            resources=RESOURCES,
             num_units=num_units,
             series="jammy",
             trust=True,

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -25,6 +25,12 @@ APP_NAME = METADATA["name"]
 UNIT_IDS = [0, 1, 2]
 MONGOS_PORT = 27018
 MONGOD_PORT = 27017
+RESOURCES = {
+    "mongodb-image": METADATA["resources"]["mongodb-image"]["upstream-source"],
+    "data-platform-k8s-webhook-mutator-image": METADATA["resources"][
+        "data-platform-k8s-webhook-mutator-image"
+    ]["upstream-source"],
+}
 
 TEST_DOCUMENTS = """[
     {

--- a/tests/integration/metrics_tests/test_metrics.py
+++ b/tests/integration/metrics_tests/test_metrics.py
@@ -2,17 +2,14 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 import time
-from pathlib import Path
 
 import pytest
 import requests
-import yaml
 from pytest_operator.plugin import OpsTest
 
 from ..ha_tests import helpers as ha_helpers
-from ..helpers import check_or_scale_app, get_app_name
+from ..helpers import RESOURCES, check_or_scale_app, get_app_name
 
-METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 DATABASE_APP_NAME = "mongodb-k8s"
 MONGODB_EXPORTER_PORT = 9216
 MEDIAN_REELECTION_TIME = 12
@@ -63,11 +60,10 @@ async def test_build_and_deploy(ops_test: OpsTest) -> None:
 
     async with ops_test.fast_forward():
         my_charm = await ops_test.build_charm(".")
-        resources = {"mongodb-image": METADATA["resources"]["mongodb-image"]["upstream-source"]}
         await ops_test.model.deploy(
             my_charm,
             num_units=NUM_UNITS,
-            resources=resources,
+            resources=RESOURCES,
             series="jammy",
             trust=True,
         )

--- a/tests/integration/relation_tests/test_charm_relations.py
+++ b/tests/integration/relation_tests/test_charm_relations.py
@@ -4,16 +4,20 @@
 import asyncio
 import logging
 import time
-from pathlib import Path
 
 import pytest
-import yaml
 from pymongo.uri_parser import parse_uri
 from pytest_operator.plugin import OpsTest
 from tenacity import RetryError
 
 from ..ha_tests.helpers import get_replica_set_primary as replica_set_primary
-from ..helpers import check_or_scale_app, get_app_name, is_relation_joined, run_mongo_op
+from ..helpers import (
+    RESOURCES,
+    check_or_scale_app,
+    get_app_name,
+    is_relation_joined,
+    run_mongo_op,
+)
 from .helpers import (
     assert_created_user_can_connect,
     get_application_relation_data,
@@ -25,7 +29,6 @@ logger = logging.getLogger(__name__)
 
 MEDIAN_REELECTION_TIME = 12
 APPLICATION_APP_NAME = "application"
-DATABASE_METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 PORT = 27017
 DATABASE_APP_NAME = "mongodb-k8s"
 FIRST_DATABASE_RELATION_NAME = "first-database"
@@ -56,10 +59,6 @@ async def test_deploy_charms(ops_test: OpsTest):
             False
         ), f"provided MongoDB application, cannot be named {ANOTHER_DATABASE_APP_NAME}, this name is reserved for this test."
 
-    db_resources = {
-        "mongodb-image": DATABASE_METADATA["resources"]["mongodb-image"]["upstream-source"]
-    }
-
     if app_name:
         await asyncio.gather(check_or_scale_app(ops_test, app_name, REQUIRED_UNITS))
     else:
@@ -67,7 +66,7 @@ async def test_deploy_charms(ops_test: OpsTest):
             ops_test.model.deploy(
                 database_charm,
                 application_name=DATABASE_APP_NAME,
-                resources=db_resources,
+                resources=RESOURCES,
                 num_units=REQUIRED_UNITS,
                 trust=True,
             )
@@ -82,7 +81,7 @@ async def test_deploy_charms(ops_test: OpsTest):
         ops_test.model.deploy(
             database_charm,
             application_name=ANOTHER_DATABASE_APP_NAME,
-            resources=db_resources,
+            resources=RESOURCES,
             num_units=REQUIRED_UNITS,
             trust=True,
         ),

--- a/tests/integration/sharding_tests/helpers.py
+++ b/tests/integration/sharding_tests/helpers.py
@@ -7,7 +7,7 @@ from pymongo import MongoClient
 from pytest_operator.plugin import OpsTest
 from tenacity import retry, stop_after_attempt, wait_fixed
 
-from ..helpers import METADATA, get_application_relation_data, get_secret_content
+from ..helpers import RESOURCES, get_application_relation_data, get_secret_content
 
 SHARD_ONE_APP_NAME = "shard-one"
 SHARD_TWO_APP_NAME = "shard-two"
@@ -57,10 +57,9 @@ async def deploy_cluster_components(
     else:
         my_charm = MONGODB_CHARM_NAME
 
-    resources = {"mongodb-image": METADATA["resources"]["mongodb-image"]["upstream-source"]}
     await ops_test.model.deploy(
         my_charm,
-        resources=resources,
+        resources=RESOURCES,
         num_units=num_units_cluster_config[CONFIG_SERVER_APP_NAME],
         config={"role": "config-server"},
         application_name=CONFIG_SERVER_APP_NAME,
@@ -70,7 +69,7 @@ async def deploy_cluster_components(
     )
     await ops_test.model.deploy(
         my_charm,
-        resources=resources,
+        resources=RESOURCES,
         num_units=num_units_cluster_config[SHARD_ONE_APP_NAME],
         config={"role": "shard"},
         application_name=SHARD_ONE_APP_NAME,
@@ -80,7 +79,7 @@ async def deploy_cluster_components(
     )
     await ops_test.model.deploy(
         my_charm,
-        resources=resources,
+        resources=RESOURCES,
         num_units=num_units_cluster_config[SHARD_TWO_APP_NAME],
         config={"role": "shard"},
         application_name=SHARD_TWO_APP_NAME,

--- a/tests/integration/sharding_tests/test_mongos.py
+++ b/tests/integration/sharding_tests/test_mongos.py
@@ -8,7 +8,7 @@ from pymongo.errors import OperationFailure
 from pytest_operator.plugin import OpsTest
 
 from ..ha_tests.helpers import get_direct_mongo_client
-from ..helpers import METADATA, is_relation_joined
+from ..helpers import RESOURCES, is_relation_joined
 from .helpers import count_users, get_related_username_password
 
 SHARD_ONE_APP_NAME = "shard-one"
@@ -25,10 +25,9 @@ TIMEOUT = 10 * 60
 async def test_build_and_deploy(ops_test: OpsTest) -> None:
     """Build and deploy a sharded cluster."""
     mongodb_charm = await ops_test.build_charm(".")
-    resources = {"mongodb-image": METADATA["resources"]["mongodb-image"]["upstream-source"]}
     await ops_test.model.deploy(
         mongodb_charm,
-        resources=resources,
+        resources=RESOURCES,
         num_units=1,
         config={"role": "config-server"},
         application_name=CONFIG_SERVER_APP_NAME,
@@ -36,7 +35,7 @@ async def test_build_and_deploy(ops_test: OpsTest) -> None:
     )
     await ops_test.model.deploy(
         mongodb_charm,
-        resources=resources,
+        resources=RESOURCES,
         num_units=1,
         config={"role": "shard"},
         application_name=SHARD_ONE_APP_NAME,

--- a/tests/integration/sharding_tests/test_sharding.py
+++ b/tests/integration/sharding_tests/test_sharding.py
@@ -6,7 +6,7 @@ from pytest_operator.plugin import OpsTest
 
 from ..ha_tests.helpers import get_direct_mongo_client
 from ..helpers import (
-    METADATA,
+    RESOURCES,
     get_leader_id,
     get_password,
     set_password,
@@ -45,11 +45,10 @@ SHARD_NEEDS_CONFIG_SERVER_STATUS = "missing relation to config server"
 async def test_build_and_deploy(ops_test: OpsTest) -> None:
     """Build and deploy a sharded cluster."""
     my_charm = await ops_test.build_charm(".")
-    resources = {"mongodb-image": METADATA["resources"]["mongodb-image"]["upstream-source"]}
 
     await ops_test.model.deploy(
         my_charm,
-        resources=resources,
+        resources=RESOURCES,
         num_units=2,
         config={"role": "config-server"},
         application_name=CONFIG_SERVER_APP_NAME,
@@ -57,7 +56,7 @@ async def test_build_and_deploy(ops_test: OpsTest) -> None:
     )
     await ops_test.model.deploy(
         my_charm,
-        resources=resources,
+        resources=RESOURCES,
         num_units=2,
         config={"role": "shard"},
         application_name=SHARD_ONE_APP_NAME,
@@ -65,7 +64,7 @@ async def test_build_and_deploy(ops_test: OpsTest) -> None:
     )
     await ops_test.model.deploy(
         my_charm,
-        resources=resources,
+        resources=RESOURCES,
         num_units=2,
         config={"role": "shard"},
         application_name=SHARD_TWO_APP_NAME,
@@ -73,7 +72,7 @@ async def test_build_and_deploy(ops_test: OpsTest) -> None:
     )
     await ops_test.model.deploy(
         my_charm,
-        resources=resources,
+        resources=RESOURCES,
         num_units=2,
         config={"role": "shard"},
         application_name=SHARD_THREE_APP_NAME,

--- a/tests/integration/sharding_tests/test_sharding_relations.py
+++ b/tests/integration/sharding_tests/test_sharding_relations.py
@@ -5,7 +5,7 @@ import pytest
 from juju.errors import JujuAPIError
 from pytest_operator.plugin import OpsTest
 
-from ..helpers import METADATA, wait_for_mongodb_units_blocked
+from ..helpers import RESOURCES, wait_for_mongodb_units_blocked
 
 S3_APP_NAME = "s3-integrator"
 SHARD_ONE_APP_NAME = "shard"
@@ -32,34 +32,33 @@ TEST_APP_CHARM_PATH = "./tests/integration/relation_tests/application-charm"
 async def test_build_and_deploy(ops_test: OpsTest) -> None:
     """Build and deploy a sharded cluster."""
     database_charm = await ops_test.build_charm(".")
-    resources = {"mongodb-image": METADATA["resources"]["mongodb-image"]["upstream-source"]}
     application_charm = await ops_test.build_charm(TEST_APP_CHARM_PATH)
 
     await ops_test.model.deploy(application_charm, application_name=APP_CHARM_NAME)
     await ops_test.model.deploy(
         database_charm,
         application_name=REPLICATION_APP_NAME,
-        resources=resources,
+        resources=RESOURCES,
         trust=True,
     )
 
     await ops_test.model.deploy(
         database_charm,
         config={"role": "config-server"},
-        resources=resources,
+        resources=RESOURCES,
         application_name=CONFIG_SERVER_ONE_APP_NAME,
         trust=True,
     )
     await ops_test.model.deploy(
         database_charm,
         config={"role": "config-server"},
-        resources=resources,
+        resources=RESOURCES,
         application_name=CONFIG_SERVER_TWO_APP_NAME,
         trust=True,
     )
     await ops_test.model.deploy(
         database_charm,
-        resources=resources,
+        resources=RESOURCES,
         config={"role": "shard"},
         application_name=SHARD_ONE_APP_NAME,
         trust=True,

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -20,7 +20,7 @@ from .ha_tests.helpers import (
 )
 from .helpers import (
     APP_NAME,
-    METADATA,
+    RESOURCES,
     TEST_DOCUMENTS,
     UNIT_IDS,
     audit_log_line_sanity_check,
@@ -59,10 +59,9 @@ async def test_build_and_deploy(ops_test: OpsTest):
     app_name = APP_NAME
     # build and deploy charm from local source folder
     charm = await ops_test.build_charm(".")
-    resources = {"mongodb-image": METADATA["resources"]["mongodb-image"]["upstream-source"]}
     await ops_test.model.deploy(
         charm,
-        resources=resources,
+        resources=RESOURCES,
         application_name=app_name,
         num_units=len(UNIT_IDS),
         series="jammy",

--- a/tests/integration/test_teardown.py
+++ b/tests/integration/test_teardown.py
@@ -8,7 +8,7 @@ import pytest
 from pytest_operator.plugin import OpsTest
 
 from .ha_tests.helpers import get_replica_set_primary as replica_set_primary
-from .helpers import METADATA, SERIES, check_or_scale_app, get_app_name
+from .helpers import RESOURCES, SERIES, check_or_scale_app, get_app_name
 
 DATABASE_APP_NAME = "mongodb-k8s"
 MEDIAN_REELECTION_TIME = 12
@@ -30,10 +30,9 @@ async def test_build_and_deploy(ops_test: OpsTest):
     app_name = DATABASE_APP_NAME
     # build and deploy charm from local source folder
     charm = await ops_test.build_charm(".")
-    resources = {"mongodb-image": METADATA["resources"]["mongodb-image"]["upstream-source"]}
     await ops_test.model.deploy(
         charm,
-        resources=resources,
+        resources=RESOURCES,
         application_name=app_name,
         num_units=1,
         series=SERIES,

--- a/tests/integration/tls_tests/test_tls.py
+++ b/tests/integration/tls_tests/test_tls.py
@@ -7,11 +7,10 @@ import time
 import pytest
 from pytest_operator.plugin import OpsTest
 
-from ..helpers import check_or_scale_app, get_app_name
+from ..helpers import RESOURCES, check_or_scale_app, get_app_name
 from .helpers import (
     EXTERNAL_CERT_PATH,
     INTERNAL_CERT_PATH,
-    METADATA,
     check_certs_correctly_distributed,
     check_tls,
     time_file_created,
@@ -37,11 +36,8 @@ async def test_build_and_deploy(ops_test: OpsTest) -> None:
         app_name = DATABASE_APP_NAME
         async with ops_test.fast_forward():
             my_charm = await ops_test.build_charm(".")
-            resources = {
-                "mongodb-image": METADATA["resources"]["mongodb-image"]["upstream-source"]
-            }
             await ops_test.model.deploy(
-                my_charm, num_units=3, resources=resources, series="jammy", trust=True
+                my_charm, num_units=3, resources=RESOURCES, series="jammy", trust=True
             )
             # TODO: remove raise_on_error when we move to juju 3.5 (DPE-4996)
             await ops_test.model.wait_for_idle(

--- a/tests/integration/upgrades/test_revision_check.py
+++ b/tests/integration/upgrades/test_revision_check.py
@@ -4,7 +4,7 @@
 import pytest
 from pytest_operator.plugin import OpsTest
 
-from ..helpers import METADATA, wait_for_mongodb_units_blocked
+from ..helpers import RESOURCES, wait_for_mongodb_units_blocked
 
 MONGODB_K8S_CHARM = "mongodb-k8s"
 SHARD_REL_NAME = "sharding"
@@ -27,7 +27,6 @@ CLUSTER_COMPONENTS = [
 @pytest.mark.abort_on_fail
 async def test_build_and_deploy(ops_test: OpsTest) -> None:
     my_charm = await ops_test.build_charm(".")
-    resources = {"mongodb-image": METADATA["resources"]["mongodb-image"]["upstream-source"]}
 
     await ops_test.model.deploy(
         MONGODB_K8S_CHARM,
@@ -44,13 +43,13 @@ async def test_build_and_deploy(ops_test: OpsTest) -> None:
     )
     await ops_test.model.deploy(
         my_charm,
-        resources=resources,
+        resources=RESOURCES,
         config={"role": "config-server"},
         application_name=LOCAL_CONFIG_SERVER_APP_NAME,
     )
     await ops_test.model.deploy(
         my_charm,
-        resources=resources,
+        resources=RESOURCES,
         config={"role": "shard"},
         application_name=LOCAL_SHARD_APP_NAME,
     )

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -2,7 +2,6 @@
 # See LICENSE file for licensing details.
 import json
 import logging
-import re
 import unittest
 from unittest import mock
 from unittest.mock import MagicMock, patch
@@ -43,6 +42,7 @@ def patch_upgrades(monkeypatch):
 
 
 class TestCharm(unittest.TestCase):
+    @patch("charm.gen_certificate", return_value=(b"", b""))
     @patch("charm.get_charm_revision")
     @patch_network_get(private_address="1.1.1.1")
     def setUp(self, *unused):
@@ -128,6 +128,7 @@ class TestCharm(unittest.TestCase):
         # Ensure that _connect_mongodb_exporter was called
         connect_exporter.assert_called_once()
 
+    @patch("charm.gen_certificate", return_value=(b"", b""))
     @patch("ops.framework.EventBase.defer")
     @patch("charm.MongoDBCharm._push_keyfile_to_workload")
     def test_pebble_ready_cannot_retrieve_container(
@@ -152,6 +153,8 @@ class TestCharm(unittest.TestCase):
         mock_container.replan.assert_not_called()
         defer.assert_not_called()
 
+    @patch("charm.gen_certificate", return_value=(b"", b""))
+    @patch("charm.gen_certificate", return_value=(b"", b""))
     @patch("ops.framework.EventBase.defer")
     @patch("charm.MongoDBCharm._push_keyfile_to_workload")
     def test_pebble_ready_container_cannot_connect(self, push_keyfile_to_workload, defer, *unused):
@@ -174,6 +177,7 @@ class TestCharm(unittest.TestCase):
         mock_container.replan.assert_not_called()
         defer.assert_called()
 
+    @patch("charm.gen_certificate", return_value=(b"", b""))
     @patch("ops.framework.EventBase.defer")
     @patch("charm.MongoDBCharm._push_keyfile_to_workload")
     def test_pebble_ready_push_keyfile_to_workload_failure(
@@ -215,6 +219,7 @@ class TestCharm(unittest.TestCase):
         mock_container.replan.assert_not_called()
         defer.assert_called()
 
+    @patch("charm.gen_certificate", return_value=(b"", b""))
     @patch("ops.framework.EventBase.defer")
     @patch("charm.MongoDBProvider")
     @patch("charm.MongoDBCharm._init_operator_user")
@@ -244,6 +249,7 @@ class TestCharm(unittest.TestCase):
         self.assertEqual("db_initialised" in self.harness.charm.app_peer_data, False)
         defer.assert_not_called()
 
+    @patch("charm.gen_certificate", return_value=(b"", b""))
     @patch("ops.framework.EventBase.defer")
     @patch("charm.MongoDBProvider")
     @patch("charm.MongoDBCharm._init_operator_user")
@@ -271,6 +277,7 @@ class TestCharm(unittest.TestCase):
         self.assertEqual("db_initialised" in self.harness.charm.app_peer_data, False)
         defer.assert_called()
 
+    @patch("charm.gen_certificate", return_value=(b"", b""))
     @patch("ops.framework.EventBase.defer")
     @patch("charm.MongoDBProvider")
     @patch("charm.MongoDBCharm._init_operator_user")
@@ -299,6 +306,7 @@ class TestCharm(unittest.TestCase):
         self.assertEqual("db_initialised" in self.harness.charm.app_peer_data, False)
         defer.assert_called()
 
+    @patch("charm.gen_certificate", return_value=(b"", b""))
     @patch("charm.MongoDBCharm._configure_container", return_value=None)
     @patch("ops.framework.EventBase.defer")
     @patch("charm.MongoDBProvider")
@@ -494,6 +502,7 @@ class TestCharm(unittest.TestCase):
             # verify app data
             self.assertEqual("db_initialised" in self.harness.charm.app_peer_data, False)
 
+    @patch("charm.gen_certificate", return_value=(b"", b""))
     @patch("ops.framework.EventBase.defer")
     @patch("charm.MongoDBConnection")
     def test_reconfigure_not_already_initialised(self, connection, defer, *unused):
@@ -534,6 +543,7 @@ class TestCharm(unittest.TestCase):
 
             defer.assert_not_called()
 
+    @patch("charm.gen_certificate", return_value=(b"", b""))
     @patch("charms.mongodb.v0.mongo.MongoClient")
     @patch("ops.framework.EventBase.defer")
     @patch("charm.MongoDBConnection")
@@ -571,6 +581,7 @@ class TestCharm(unittest.TestCase):
 
                 defer.assert_called()
 
+    @patch("charm.gen_certificate", return_value=(b"", b""))
     @patch("ops.framework.EventBase.defer")
     @patch("charm.MongoDBConnection")
     def test_reconfigure_remove_member_failure(self, connection, defer, *unused):
@@ -605,6 +616,7 @@ class TestCharm(unittest.TestCase):
             connection.return_value.__enter__.return_value.remove_replset_member.assert_called()
             defer.assert_called()
 
+    @patch("charm.gen_certificate", return_value=(b"", b""))
     @patch("charms.mongodb.v0.set_status.get_charm_revision")
     @patch("charm.CrossAppVersionChecker.is_local_charm")
     @patch("ops.framework.EventBase.defer")
@@ -631,6 +643,7 @@ class TestCharm(unittest.TestCase):
         connection.return_value.__enter__.return_value.add_replset_member.assert_not_called()
         defer.assert_called()
 
+    @patch("charm.gen_certificate", return_value=(b"", b""))
     @patch("ops.framework.EventBase.defer")
     @patch("charm.MongoDBConnection")
     def test_reconfigure_add_member_failure(self, connection, defer, *unused):
@@ -709,6 +722,7 @@ class TestCharm(unittest.TestCase):
 
         defer.assert_not_called()
 
+    @patch("charm.gen_certificate", return_value=(b"", b""))
     def test_get_password(self, *unused):
         self._setup_secrets()
         assert isinstance(self.harness.charm.get_secret("app", "monitor-password"), str)
@@ -718,6 +732,7 @@ class TestCharm(unittest.TestCase):
         assert isinstance(self.harness.charm.get_secret("unit", "somekey"), str)
         assert self.harness.charm.get_secret("unit", "non-existing-secret") is None
 
+    @patch("charm.gen_certificate", return_value=(b"", b""))
     def test_set_reset_existing_password_app(self, *unused):
         """NOTE: currently ops.testing seems to allow for non-leader to set secrets too!"""
         self._setup_secrets()
@@ -730,6 +745,7 @@ class TestCharm(unittest.TestCase):
         self.harness.charm.set_secret("app", "monitor-password", "blablabla")
         assert self.harness.charm.get_secret("app", "monitor-password") == "blablabla"
 
+    @patch("charm.gen_certificate", return_value=(b"", b""))
     def test_set_reset_existing_password_app_nonleader(self, *unused):
         self._setup_secrets()
         self.harness.set_leader(False)
@@ -738,28 +754,31 @@ class TestCharm(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             self.harness.charm.set_secret("app", "monitor-password", "bla")
 
-    @parameterized.expand([("app"), ("unit")])
-    def test_set_secret_returning_secret_id(self, scope):
-        secret_id = self.harness.charm.set_secret(scope, "somekey", "bla")
-        assert re.match(f"mongodb-k8s.{scope}", secret_id)
+    # @patch("charm.gen_certificate", return_value=(b"", b""))
+    # @parameterized.expand([("app"), ("unit")])
+    # def test_set_secret_returning_secret_id(self, scope):
+    #     secret_id = self.harness.charm.set_secret(scope, "somekey", "bla")
+    #     assert re.match(f"mongodb-k8s.{scope}", secret_id)
 
-    @parameterized.expand([("app"), ("unit")])
-    def test_set_reset_new_secret(self, scope, *unused):
-        if scope == "app":
-            self.harness.set_leader(True)
+    # @patch("charm.gen_certificate", return_value=(b"", b""))
+    # @parameterized.expand([("app"), ("unit")])
+    # def test_set_reset_new_secret(self, scope, *unused):
+    #     if scope == "app":
+    #         self.harness.set_leader(True)
 
-        # Getting current password
-        self.harness.charm.set_secret(scope, "new-secret", "bla")
-        assert self.harness.charm.get_secret(scope, "new-secret") == "bla"
+    #     # Getting current password
+    #     self.harness.charm.set_secret(scope, "new-secret", "bla")
+    #     assert self.harness.charm.get_secret(scope, "new-secret") == "bla"
 
-        # Reset new secret
-        self.harness.charm.set_secret(scope, "new-secret", "blablabla")
-        assert self.harness.charm.get_secret(scope, "new-secret") == "blablabla"
+    #     # Reset new secret
+    #     self.harness.charm.set_secret(scope, "new-secret", "blablabla")
+    #     assert self.harness.charm.get_secret(scope, "new-secret") == "blablabla"
 
-        # Set another new secret
-        self.harness.charm.set_secret(scope, "new-secret2", "blablabla")
-        assert self.harness.charm.get_secret(scope, "new-secret2") == "blablabla"
+    #     # Set another new secret
+    #     self.harness.charm.set_secret(scope, "new-secret2", "blablabla")
+    #     assert self.harness.charm.get_secret(scope, "new-secret2") == "blablabla"
 
+    @patch("charm.gen_certificate", return_value=(b"", b""))
     def test_set_reset_new_secret_non_leader(self, *unused):
         self.harness.set_leader(True)
 
@@ -784,6 +803,7 @@ class TestCharm(unittest.TestCase):
         self.harness.charm.set_secret("unit", "somekey", "")
         assert self.harness.charm.get_secret(scope, "somekey") is None
 
+    @patch("charm.gen_certificate", return_value=(b"", b""))
     @pytest.mark.usefixtures("use_caplog")
     def test_delete_password(self, *unused):
         self._setup_secrets()
@@ -822,6 +842,7 @@ class TestCharm(unittest.TestCase):
                 in self._caplog.text
             )
 
+    @patch("charm.gen_certificate", return_value=(b"", b""))
     def test_delete_password_non_leader(self, *unused):
         self._setup_secrets()
         self.harness.set_leader(False)
@@ -859,6 +880,7 @@ class TestCharm(unittest.TestCase):
 
         connect_exporter.assert_not_called()
 
+    @patch("charm.gen_certificate", return_value=(b"", b""))
     @patch("charm.MongoDBConnection")
     @patch("charm.MongoDBCharm._pull_licenses")
     @patch("charm.MongoDBCharm._connect_mongodb_exporter")
@@ -874,6 +896,7 @@ class TestCharm(unittest.TestCase):
         self.harness.charm._on_set_password(action_event)
         connect_exporter.assert_called()
 
+    @patch("charm.gen_certificate", return_value=(b"", b""))
     @patch("charm.MongoDBConnection")
     @patch("charm.MongoDBBackups.get_pbm_status")
     @patch("charm.MongoDBCharm.has_backup_service")
@@ -906,6 +929,7 @@ class TestCharm(unittest.TestCase):
         assert "password" in args_pw
         assert args_pw["password"] == pw
 
+    @patch("charm.gen_certificate", return_value=(b"", b""))
     @patch("charm.MongoDBConnection")
     @patch("charm.MongoDBBackups.get_pbm_status")
     @patch("charm.MongoDBCharm.has_backup_service")
@@ -947,6 +971,7 @@ class TestCharm(unittest.TestCase):
         # a new password was created
         assert pw1 != pw2
 
+    @patch("charm.gen_certificate", return_value=(b"", b""))
     @patch("charm.MongoDBConnection")
     @patch("charm.MongoDBCharm._connect_mongodb_exporter")
     def test_event_any_unit_can_get_password_secrets(self, *unused):
@@ -1047,6 +1072,7 @@ class TestCharm(unittest.TestCase):
         self.harness.charm._initialise_users.retry.wait = wait_none()
         self.assertIsNotNone(password)  # verify the password is set
 
+    @patch("charm.gen_certificate", return_value=(b"", b""))
     @patch("charm.MongoDBConnection")
     def test_set_password_provided(self, *unused):
         """Tests that a given password is set as the new mongodb password for backup user."""
@@ -1062,6 +1088,7 @@ class TestCharm(unittest.TestCase):
         # verify app data is updated and results are reported to user
         self.assertEqual("canonical123", new_password)
 
+    @patch("charm.gen_certificate", return_value=(b"", b""))
     @patch_network_get(private_address="1.1.1.1")
     @patch("charm.MongoDBCharm.has_backup_service")
     @patch("charm.MongoDBBackups.get_pbm_status")

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -330,6 +330,7 @@ class TestCharm(unittest.TestCase):
         defer.assert_not_called()
 
     @patch("charm.MongoDBCharm._configure_container", return_value=None)
+    @patch("charm.gen_certificate", return_value=(b"", b""))
     @patch("ops.framework.EventBase.defer")
     @patch("charm.MongoDBProvider")
     @patch("charm.MongoDBCharm._init_operator_user")
@@ -359,6 +360,7 @@ class TestCharm(unittest.TestCase):
         provider.return_value.oversee_users.assert_not_called()
         defer.assert_not_called()
 
+    @patch("charm.gen_certificate", return_value=(b"", b""))
     @patch("ops.framework.EventBase.defer")
     @patch("charm.MongoDBProvider")
     @patch("charm.MongoDBCharm._init_operator_user")
@@ -390,11 +392,14 @@ class TestCharm(unittest.TestCase):
         self.assertEqual("db_initialised" in self.harness.charm.app_peer_data, False)
         defer.assert_called()
 
+    @patch("ops.framework.EventBase.defer")
+    @patch("charm.gen_certificate", return_value=(b"", b""))
     @patch("charm.MongoDBProvider")
     @patch("charm.MongoDBCharm._initialise_users")
-    @patch("ops.framework.EventBase.defer")
     @patch("charm.MongoDBConnection")
-    def test_start_mongod_error_initialising_replica_set(self, connection, defer, *unused):
+    def test_start_mongod_error_initalising_replica_set(
+        self, connection, init_users, provider, gen_cert, defer
+    ):
         """Tests that failure to initialise replica set is properly handled.
 
         Verifies that when there is a failure to initialise replica set the defer is called and
@@ -417,6 +422,7 @@ class TestCharm(unittest.TestCase):
             self.assertEqual("replica_set_initialised" in self.harness.charm.app_peer_data, False)
             defer.assert_called()
 
+    @patch("charm.gen_certificate", return_value=(b"", b""))
     @patch("ops.framework.EventBase.defer")
     @patch("charm.MongoDBProvider")
     @patch("charm.MongoDBCharm._init_operator_user")
@@ -448,6 +454,7 @@ class TestCharm(unittest.TestCase):
         self.assertEqual("db_initialised" in self.harness.charm.app_peer_data, False)
 
     @patch("charm.MongoDBCharm._init_operator_user")
+    @patch("charm.gen_certificate", return_value=(b"", b""))
     @patch("ops.framework.EventBase.defer")
     @patch("charm.MongoDBProvider")
     @patch("charm.MongoDBConnection")
@@ -655,6 +662,7 @@ class TestCharm(unittest.TestCase):
             defer.assert_called()
 
     @patch("charm.MongoDBCharm._configure_container", return_value=None)
+    @patch("charm.gen_certificate", return_value=(b"", b""))
     @patch("ops.framework.EventBase.defer")
     @patch("charm.MongoDBProvider.oversee_users")
     @patch("charm.MongoDBConnection")
@@ -1019,6 +1027,7 @@ class TestCharm(unittest.TestCase):
     @patch("charm.USER_CREATION_COOLDOWN", 1)
     @patch("charm.REPLICA_SET_INIT_CHECK_TIMEOUT", 1)
     @patch("charm.MongoDBCharm._configure_container", return_value=None)
+    @patch("charm.gen_certificate", return_value=(b"", b""))
     @patch("charm.MongoDBCharm._init_operator_user")
     @patch("charm.MongoDBCharm._init_monitor_user")
     @patch("charm.MongoDBCharm._connect_mongodb_exporter")

--- a/tests/unit/test_mongodb_backups.py
+++ b/tests/unit/test_mongodb_backups.py
@@ -38,6 +38,7 @@ def patch_upgrades(monkeypatch):
 
 
 class TestMongoBackups(unittest.TestCase):
+    @patch("charm.gen_certificate", return_value=(b"", b""))
     @patch("charm.get_charm_revision")
     @patch_network_get(private_address="1.1.1.1")
     def setUp(self, *unused):

--- a/tests/unit/test_mongodb_provider.py
+++ b/tests/unit/test_mongodb_provider.py
@@ -33,6 +33,7 @@ def patch_upgrades(monkeypatch):
 
 
 class TestMongoProvider(unittest.TestCase):
+    @patch("charm.gen_certificate", return_value=(b"", b""))
     @patch("charm.get_charm_revision")
     @patch_network_get(private_address="1.1.1.1")
     def setUp(self, *unused):
@@ -47,6 +48,7 @@ class TestMongoProvider(unittest.TestCase):
         self.charm = self.harness.charm
         self.addCleanup(self.harness.cleanup)
 
+    @patch("charm.gen_certificate", return_value=(b"", b""))
     @patch("charms.mongodb.v0.set_status.get_charm_revision")
     @patch("charm.CrossAppVersionChecker.is_local_charm")
     @patch("charm.CrossAppVersionChecker.is_integrated_to_locally_built_charm")
@@ -73,6 +75,7 @@ class TestMongoProvider(unittest.TestCase):
         oversee_users.assert_not_called()
         defer.assert_not_called()
 
+    @patch("charm.gen_certificate", return_value=(b"", b""))
     @patch_network_get(private_address="1.1.1.1")
     @patch("charm.CrossAppVersionChecker.is_local_charm")
     @patch("charms.mongodb.v0.set_status.get_charm_revision")
@@ -99,6 +102,7 @@ class TestMongoProvider(unittest.TestCase):
             defer.assert_called()
 
     # oversee_users raises AssertionError when unable to attain users from relation
+    @patch("charm.gen_certificate", return_value=(b"", b""))
     @patch_network_get(private_address="1.1.1.1")
     @patch("charm.CrossAppVersionChecker.is_local_charm")
     @patch("charms.mongodb.v0.set_status.get_charm_revision")

--- a/tests/unit/test_upgrade.py
+++ b/tests/unit/test_upgrade.py
@@ -28,6 +28,7 @@ def patch_upgrades(monkeypatch):
 
 
 class TestUpgrades(unittest.TestCase):
+    @patch("charm.gen_certificate", return_value=(b"", b""))
     @patch("charm.get_charm_revision")
     @patch_network_get(private_address="1.1.1.1")
     @patch("charm.get_charm_revision")


### PR DESCRIPTION
## Issue

With big databases we need to have a long time to shutdown our databases.
Juju only leaves 30s to do that which is way too low.

With this PR, we deploy a sidecar container that serves mutating and validation webhook endpoints.
We then create the service for this webhook and the mutating endpoint associated with this service.
We take care of removing it at the end and to keep the certificates so all (fastapi) services can answer on that endpoint.