### PR TITLE
feat: Avoid patching private ops testing

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1280,14 +1280,14 @@ files = [
 
 [[package]]
 name = "mongo-charms-single-kernel"
-version = "0.0.1"
+version = "0.0.2"
 description = "Shared and reusable code for Mongo-related charms"
 optional = false
 python-versions = "<4.0,>=3.10"
 groups = ["main", "integration", "unit"]
 files = [
-    {file = "mongo_charms_single_kernel-0.0.1-py3-none-any.whl", hash = "sha256:8aba95c307e9c094c625f848122bf89d89803a825b1cff708e57ec3b52228da4"},
-    {file = "mongo_charms_single_kernel-0.0.1.tar.gz", hash = "sha256:943c13535434b5f9de0717a97731321f8220188c5a043388615e9715c9450dce"},
+    {file = "mongo_charms_single_kernel-0.0.2-py3-none-any.whl", hash = "sha256:a1f3373e935102969bc1d8585127b23cefa7c8a4347f1ccf2911b8a967c37fe9"},
+    {file = "mongo_charms_single_kernel-0.0.2.tar.gz", hash = "sha256:9444dcf4baf1859274b9082f2b44b2b1ea167e3f343cecb3b48812b1260c5af4"},
 ]
 
 [package.dependencies]
@@ -2774,4 +2774,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10.12"
-content-hash = "1f5614ba591b65b5e62025e70251472cefaa1fb9c4aaf01011ec9e1e4892ef6c"
+content-hash = "41d299a52baceabfc5406dc5f7c2b4e50973a3576e45f791f594aa7364a5979f"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1280,14 +1280,14 @@ files = [
 
 [[package]]
 name = "mongo-charms-single-kernel"
-version = "0.0.2"
+version = "0.0.4"
 description = "Shared and reusable code for Mongo-related charms"
 optional = false
 python-versions = "<4.0,>=3.10"
 groups = ["main", "integration", "unit"]
 files = [
-    {file = "mongo_charms_single_kernel-0.0.2-py3-none-any.whl", hash = "sha256:a1f3373e935102969bc1d8585127b23cefa7c8a4347f1ccf2911b8a967c37fe9"},
-    {file = "mongo_charms_single_kernel-0.0.2.tar.gz", hash = "sha256:9444dcf4baf1859274b9082f2b44b2b1ea167e3f343cecb3b48812b1260c5af4"},
+    {file = "mongo_charms_single_kernel-0.0.4-py3-none-any.whl", hash = "sha256:2cd8c277509bb3c086cb9796c2e6036b9840859e511a686c79385407f4ba3ef3"},
+    {file = "mongo_charms_single_kernel-0.0.4.tar.gz", hash = "sha256:6186e631153bb94af0d2c80da7df6d4f55019f35c928ab2d77fa644c00b2b57c"},
 ]
 
 [package.dependencies]
@@ -2774,4 +2774,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10.12"
-content-hash = "41d299a52baceabfc5406dc5f7c2b4e50973a3576e45f791f594aa7364a5979f"
+content-hash = "8a7fc3b4923fce58b4d6dc79d27fd0b9cf1f8971a6ee4a3f1d3bafc8797036db"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires-poetry = ">=2.0.0"
 
 [tool.poetry.dependencies]
 python = "^3.10.12"
-mongo-charms-single-kernel = "~0.0.2"
+mongo-charms-single-kernel = "~0.0.4"
 dacite = "==1.8.0"
 ops = "~2.15.0"
 pymongo = "^4.7.3"
@@ -57,13 +57,13 @@ coverage = {extras = ["toml"], version = "^7.5.0"}
 pytest = "^8.1.1"
 pytest-mock = "*"
 parameterized = "^0.9.0"
-mongo-charms-single-kernel = "~0.0.2"
+mongo-charms-single-kernel = "~0.0.4"
 dacite = "==1.8.0"
 
 [tool.poetry.group.integration.dependencies]
 allure-pytest = "^2.13.5"
 ops = "~2.15.0"
-mongo-charms-single-kernel = "~0.0.2"
+mongo-charms-single-kernel = "~0.0.4"
 dacite = "==1.8.0"
 tenacity = "^8.2.3"
 pymongo = "^4.7.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires-poetry = ">=2.0.0"
 
 [tool.poetry.dependencies]
 python = "^3.10.12"
-mongo-charms-single-kernel = "~0.0.1"
+mongo-charms-single-kernel = "~0.0.2"
 dacite = "==1.8.0"
 ops = "~2.15.0"
 pymongo = "^4.7.3"
@@ -57,13 +57,13 @@ coverage = {extras = ["toml"], version = "^7.5.0"}
 pytest = "^8.1.1"
 pytest-mock = "*"
 parameterized = "^0.9.0"
-mongo-charms-single-kernel = "~0.0.1"
+mongo-charms-single-kernel = "~0.0.2"
 dacite = "==1.8.0"
 
 [tool.poetry.group.integration.dependencies]
 allure-pytest = "^2.13.5"
 ops = "~2.15.0"
-mongo-charms-single-kernel = "~0.0.1"
+mongo-charms-single-kernel = "~0.0.2"
 dacite = "==1.8.0"
 tenacity = "^8.2.3"
 pymongo = "^4.7.3"

--- a/tests/integration/sharding_tests/test_mongos.py
+++ b/tests/integration/sharding_tests/test_mongos.py
@@ -49,6 +49,7 @@ async def test_build_and_deploy(ops_test: OpsTest) -> None:
     await ops_test.model.deploy(
         MONGOS_APP_NAME,
         channel="6/edge",
+        trust=True,
     )
 
     await ops_test.model.wait_for_idle(

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -3,27 +3,7 @@
 # See LICENSE file for licensing details.
 
 from pathlib import Path
-from typing import Callable
-from unittest.mock import patch
 
 import yaml
 
 METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
-
-
-def patch_network_get(private_address="10.1.157.116") -> Callable:
-    def network_get(*args, **kwargs) -> dict:
-        """Patch for the not-yet-implemented testing backend needed for `bind_address`.
-
-        This patch decorator can be used for cases such as:
-        self.model.get_binding(event.relation).network.bind_address
-        """
-        return {
-            "bind-addresses": [
-                {
-                    "addresses": [{"value": private_address}],
-                }
-            ]
-        }
-
-    return patch("ops.testing._TestingModelBackend.network_get", network_get)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -23,8 +23,6 @@ from single_kernel_mongo.utils.mongodb_users import (
 
 from charm import MongoDBK8sCharm
 
-from .helpers import patch_network_get
-
 PYMONGO_EXCEPTIONS = [
     (ConnectionFailure("error message"), ConnectionFailure),
     (ConfigurationError("error message"), ConfigurationError),
@@ -64,7 +62,6 @@ def patch_is_ready(mocker):
 
 class TestCharm(unittest.TestCase):
     @patch("single_kernel_mongo.managers.mongodb_operator.get_charm_revision")
-    @patch_network_get(private_address="1.1.1.1")
     def setUp(self, *unused):
         self.maxDiff = None
         self.harness = Harness(MongoDBK8sCharm)
@@ -710,7 +707,6 @@ class TestCharm(unittest.TestCase):
 
         connect_exporter.assert_not_called()
 
-    @patch_network_get(private_address="1.1.1.1")
     @patch("single_kernel_mongo.utils.mongo_connection.MongoConnection.set_user_password")
     @patch(
         "single_kernel_mongo.managers.config.MongoDBExporterConfigManager.configure_and_restart"
@@ -724,7 +720,6 @@ class TestCharm(unittest.TestCase):
         self.harness.run_action("set-password", {"username": "monitor"})
         connect_exporter.assert_called()
 
-    @patch_network_get(private_address="1.1.1.1")
     @patch("single_kernel_mongo.utils.mongo_connection.MongoConnection.set_user_password")
     @patch(
         "single_kernel_mongo.managers.config.MongoDBExporterConfigManager.configure_and_restart"
@@ -821,7 +816,6 @@ class TestCharm(unittest.TestCase):
         # verify app data is updated and results are reported to user
         self.assertEqual("canonical123", new_password)
 
-    @patch_network_get(private_address="1.1.1.1")
     @patch("single_kernel_mongo.managers.backups.BackupManager.get_status")
     def test_set_backup_password_pbm_busy(self, pbm_status):
         """Tests changes to passwords fail when pbm is restoring/backing up."""

--- a/tests/unit/test_mongodb_backups.py
+++ b/tests/unit/test_mongodb_backups.py
@@ -17,8 +17,6 @@ from single_kernel_mongo.exceptions import (
 
 from charm import MongoDBK8sCharm
 
-from .helpers import patch_network_get
-
 RELATION_NAME = "s3-credentials"
 
 
@@ -43,7 +41,6 @@ def patch_upgrades(monkeypatch):
 
 class TestMongoBackups(unittest.TestCase):
     @patch("single_kernel_mongo.managers.mongodb_operator.get_charm_revision")
-    @patch_network_get(private_address="1.1.1.1")
     def setUp(self, *unused):
         self.harness = Harness(MongoDBK8sCharm)
         self.harness.add_relation("database-peers", "database-peers")
@@ -319,7 +316,6 @@ class TestMongoBackups(unittest.TestCase):
             {"bucket": "hat"},
         )
 
-    @patch_network_get(private_address="1.1.1.1")
     @patch(
         "single_kernel_mongo.core.k8s_workload.KubernetesWorkload.active",
         return_value=True,
@@ -346,7 +342,6 @@ class TestMongoBackups(unittest.TestCase):
 
         self.assertTrue(isinstance(self.harness.charm.unit.status, BlockedStatus))
 
-    @patch_network_get(private_address="1.1.1.1")
     @patch("single_kernel_mongo.managers.backups.BackupManager.set_config_options")
     @patch("single_kernel_mongo.managers.backups.BackupManager.resync_config_options")
     @patch("ops.framework.EventBase.defer")
@@ -380,7 +375,6 @@ class TestMongoBackups(unittest.TestCase):
         )
         self.assertTrue(isinstance(self.harness.charm.unit.status, BlockedStatus))
 
-    @patch_network_get(private_address="1.1.1.1")
     @patch("single_kernel_mongo.managers.backups.BackupManager.set_config_options")
     @patch("single_kernel_mongo.managers.backups.BackupManager.resync_config_options")
     @patch("ops.framework.EventBase.defer")
@@ -411,7 +405,6 @@ class TestMongoBackups(unittest.TestCase):
         defer.assert_called()
         self.assertTrue(isinstance(self.harness.charm.unit.status, WaitingStatus))
 
-    @patch_network_get(private_address="1.1.1.1")
     @patch("single_kernel_mongo.managers.backups.BackupManager.set_config_options")
     @patch("single_kernel_mongo.managers.backups.BackupManager.resync_config_options")
     @patch("ops.framework.EventBase.defer")
@@ -445,7 +438,6 @@ class TestMongoBackups(unittest.TestCase):
         defer.assert_called()
         self.assertTrue(isinstance(self.harness.charm.unit.status, WaitingStatus))
 
-    @patch_network_get(private_address="1.1.1.1")
     @patch("single_kernel_mongo.managers.backups.BackupManager.set_config_options")
     @patch("single_kernel_mongo.managers.backups.BackupManager.resync_config_options")
     @patch("ops.framework.EventBase.defer")

--- a/tests/unit/test_mongodb_provider.py
+++ b/tests/unit/test_mongodb_provider.py
@@ -12,8 +12,6 @@ from pymongo.errors import ConfigurationError, ConnectionFailure, OperationFailu
 
 from charm import MongoDBK8sCharm
 
-from .helpers import patch_network_get
-
 PYMONGO_EXCEPTIONS = [
     (ConnectionFailure("error message"), ConnectionFailure),
     (ConfigurationError("error message"), ConfigurationError),
@@ -49,7 +47,6 @@ def patch_upgrades(monkeypatch):
 
 class TestMongoProvider(unittest.TestCase):
     @patch("single_kernel_mongo.managers.mongodb_operator.get_charm_revision")
-    @patch_network_get(private_address="1.1.1.1")
     def setUp(self, *unused):
         self.harness = Harness(MongoDBK8sCharm)
         mongo_resource = {
@@ -106,7 +103,6 @@ class TestMongoProvider(unittest.TestCase):
         oversee_users.assert_not_called()
         defer.assert_not_called()
 
-    @patch_network_get(private_address="1.1.1.1")
     @patch("single_kernel_mongo.managers.mongodb_operator.get_charm_revision")
     @patch("ops.framework.EventBase.defer")
     @patch("single_kernel_mongo.managers.mongo.MongoManager.reconcile_mongo_users_and_dbs")
@@ -131,7 +127,6 @@ class TestMongoProvider(unittest.TestCase):
             defer.assert_called()
 
     # oversee_users raises AssertionError when unable to attain users from relation
-    @patch_network_get(private_address="1.1.1.1")
     @patch("single_kernel_mongo.managers.mongodb_operator.get_charm_revision")
     @patch("ops.framework.EventBase.defer")
     @patch("single_kernel_mongo.managers.mongo.MongoManager.reconcile_mongo_users_and_dbs")
@@ -156,7 +151,6 @@ class TestMongoProvider(unittest.TestCase):
                 else:
                     self.harness.remove_relation_unit(relation_id, "consumer/0")
 
-    @patch_network_get(private_address="1.1.1.1")
     @patch("single_kernel_mongo.utils.mongo_connection.MongoConnection.user_exists")
     def test_oversee_users_get_users_failure(self, mock_user_exists):
         """Verifies that when unable to retrieve users from mongod an exception is raised."""
@@ -178,7 +172,6 @@ class TestMongoProvider(unittest.TestCase):
                         relation_changed=True,
                     )
 
-    @patch_network_get(private_address="1.1.1.1")
     @patch(
         "single_kernel_mongo.utils.mongo_connection.MongoConnection.user_exists",
         return_value=False,
@@ -209,7 +202,6 @@ class TestMongoProvider(unittest.TestCase):
                     )
                 set_credentials.assert_not_called()
 
-    @patch_network_get(private_address="1.1.1.1")
     @patch("single_kernel_mongo.managers.mongo.MongoManager.add_user")
     @patch("single_kernel_mongo.managers.mongo.MongoManager.update_user")
     @patch("single_kernel_mongo.managers.mongo.MongoManager.remove_user")
@@ -231,7 +223,6 @@ class TestMongoProvider(unittest.TestCase):
         )
         drop_db.assert_not_called()
 
-    @patch_network_get(private_address="1.1.1.1")
     @patch("single_kernel_mongo.managers.mongo.MongoManager.add_user")
     @patch("single_kernel_mongo.managers.mongo.MongoManager.update_user")
     @patch("single_kernel_mongo.managers.mongo.MongoManager.remove_user")
@@ -269,7 +260,6 @@ class TestMongoProvider(unittest.TestCase):
             ["database", True, False],
         ]
     )
-    @patch_network_get(private_address="1.1.1.1")
     @patch(
         "single_kernel_mongo.lib.charms.data_platform_libs.v0.data_interfaces.DatabaseProviderData.set_credentials"
     )

--- a/tests/unit/test_upgrade.py
+++ b/tests/unit/test_upgrade.py
@@ -19,8 +19,6 @@ from tenacity import Future, RetryError
 
 from charm import MongoDBK8sCharm
 
-from .helpers import patch_network_get
-
 
 @pytest.fixture(autouse=True)
 def patch_upgrades(monkeypatch):
@@ -43,7 +41,6 @@ def patch_upgrades(monkeypatch):
 
 class TestUpgrades(unittest.TestCase):
     @patch("single_kernel_mongo.managers.mongodb_operator.get_charm_revision")
-    @patch_network_get(private_address="1.1.1.1")
     def setUp(self, *unused):
         self.harness = Harness(MongoDBK8sCharm)
         self.addCleanup(self.harness.cleanup)


### PR DESCRIPTION
## Issue

 * We were still patching ops testing

## Solution

 * Stop patching it, similar to https://github.com/canonical/mongo-single-kernel-library/pull/17

## Miscellaneous
 * Bumps Mongo single kernel library
