### PR TITLE
patch: migrate from action-based password management to config-option-based passwords 

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -4,26 +4,6 @@
 get-primary:
   description: Report primary replica
 
-get-password:
-  description: Change the system user's password used by charm.
-    It is for internal charm users and SHOULD NOT be used by applications.
-  params:
-    username:
-      type: string
-      description: The username, the default value 'operator'.
-        Possible values - operator, monitor.
-set-password:
-  description: Change the system user's password used by charm.
-    It is for internal charm users and SHOULD NOT be used by applications.
-  params:
-    username:
-      type: string
-      description: The username, the default value 'operator'.
-        Possible values - operator, monitor.
-    password:
-      type: string
-      description: The password will be auto-generated if this option is not specified.
-
 create-backup:
   description: Create a database backup.
     S3 credentials are retrieved from a relation with the S3 integrator charm.

--- a/config.yaml
+++ b/config.yaml
@@ -26,3 +26,12 @@ options:
       `{PROVIDED_USER}` should be used only if no value in the `ldap-user-to-do-mapping` config option is provided.
       If this configuration is not provided, a default string will be computed based on the base_dn returned by the GLAuth k8s charm.
       example: “dc=example,dc=com??sub?(&(objectClass=groupOfNames)(member={USER}))"
+  system-users:
+    type: secret
+    description: |
+      Configure the internal system users and their passwords. The passwords will
+      be auto-generated if this option is not set. It is for internal use only
+      and SHOULD NOT be used by applications. This must be a Juju Secret URI pointing
+      to a secret that contains a map with the following content: `<username>: <password>`.
+      Possible users: `backup`, `logrorate`, `monitor`, `operator`.
+      This option is only compatible with `replication` and `config-server` roles.

--- a/poetry.lock
+++ b/poetry.lock
@@ -1532,14 +1532,14 @@ files = [
 
 [[package]]
 name = "mongo-charms-single-kernel"
-version = "1.8.2"
+version = "1.8.3"
 description = "Shared and reusable code for Mongo-related charms"
 optional = false
 python-versions = "<4.0,>=3.10"
 groups = ["main", "integration", "unit"]
 files = [
-    {file = "mongo_charms_single_kernel-1.8.2-py3-none-any.whl", hash = "sha256:a2394de0744e5d785143380bf6d815e85a8065c55c341b92a7af2bb698e9e024"},
-    {file = "mongo_charms_single_kernel-1.8.2.tar.gz", hash = "sha256:505f618e8e482ad13cdb1d2c31970cd7f8298cd5f808cb7b3134d882a833fbe1"},
+    {file = "mongo_charms_single_kernel-1.8.3-py3-none-any.whl", hash = "sha256:7fd5062fec04ba022c1e1547cdbe4283ac01e8b015e0f53ef628541b5ace20b9"},
+    {file = "mongo_charms_single_kernel-1.8.3.tar.gz", hash = "sha256:30474d3d000a9caa38f5f8aa3562fc2f211e93a929cda00bce75ee73aa7d7716"},
 ]
 
 [package.dependencies]
@@ -3118,4 +3118,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10.12"
-content-hash = "cd48c346bd17d60edda9414d4b95e78959b2a6a8ba74c0e3cc50b8097dcd62d0"
+content-hash = "f28e15048eb4749071ad9d487a3011a9d64549d3e134e2482c82ef6689cc830d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires-poetry = ">=2.0.0"
 
 [tool.poetry.dependencies]
 python = "^3.10.12"
-mongo-charms-single-kernel = "1.8.2"
+mongo-charms-single-kernel = "1.8.3"
 ops = ">=2.21"
 pymongo = "^4.7.3"
 pyyaml = "^6.0.1"
@@ -56,12 +56,12 @@ coverage = {extras = ["toml"], version = "^7.5.0"}
 pytest = "^8.1.1"
 pytest-mock = "*"
 parameterized = "^0.9.0"
-mongo-charms-single-kernel = "1.8.2"
+mongo-charms-single-kernel = "1.8.3"
 
 [tool.poetry.group.integration.dependencies]
 allure-pytest = "^2.13.5"
 ops = ">=2.21"
-mongo-charms-single-kernel = "1.8.2"
+mongo-charms-single-kernel = "1.8.3"
 pymongo = "^4.7.3"
 parameterized = "^0.9.0"
 lightkube = "^0.15.3"

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -23,6 +23,10 @@ SERIES = "jammy"
 logger = logging.getLogger(__name__)
 
 
+class SecretNotFoundError(Exception):
+    """Raised when a secret is not found."""
+
+
 class Status:
     """Model class for status."""
 
@@ -222,20 +226,30 @@ async def get_direct_mongo_client(
 
 async def get_password(
     ops_test: OpsTest,
-    unit_id: int = 0,
-    username: str = "operator",
-    app_name: str = APP_NAME,
+    username: str,
+    app_name: str,
 ) -> str:
-    """Use the charm action to retrieve the password from provided unit.
+    """Retrieve the password for a given user from the application's Juju secret."""
+    secret = await get_secret_by_label(ops_test, label=f"{app_name}.app")
+    return secret.get(f"{username}-password")
 
-    Returns:
-        String with the password stored on the peer relation databag.
-    """
-    action = await ops_test.model.units.get(f"{app_name}/{unit_id}").run_action(
-        "get-password", **{"username": username}
-    )
-    action = await action.wait()
-    return action.results["password"]
+
+async def get_secret_by_label(ops_test: OpsTest, label: str) -> dict[str, str]:
+    secrets_raw = await ops_test.juju("list-secrets")
+    secret_ids = [
+        secret_line.split()[0] for secret_line in secrets_raw[1].split("\n")[1:] if secret_line
+    ]
+
+    for secret_id in secret_ids:
+        secret_data_raw = await ops_test.juju(
+            "show-secret", "--format", "json", "--reveal", secret_id
+        )
+        secret_data = json.loads(secret_data_raw[1])
+
+        if label == secret_data[secret_id].get("label"):
+            return secret_data[secret_id]["content"]["Data"]
+
+    raise SecretNotFoundError(f"Secret with label {label} not found.")
 
 
 async def mongodb_uri(
@@ -252,7 +266,7 @@ async def mongodb_uri(
     hosts = [f"{host}:{port}" for host in addresses]
     hosts = ",".join(hosts)
 
-    password = await get_password(ops_test, 0, username=username, app_name=app_name)
+    password = await get_password(ops_test, username=username, app_name=app_name)
 
     return f"mongodb://{username}:{password}@{hosts}/admin"
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -8,18 +8,14 @@ from unittest.mock import patch
 import pytest
 from data_platform_helpers.advanced_statuses.models import StatusObject
 from ops.pebble import PathError, ProtocolError
-from ops.testing import ActionFailed, Harness
+from ops.testing import Harness
 from parameterized import parameterized
 from pymongo.errors import ConfigurationError, ConnectionFailure, OperationFailure
 from single_kernel_mongo.config.literals import Scope
 from single_kernel_mongo.core.structured_config import MongoDBRoles
 from single_kernel_mongo.exceptions import WorkloadExecError
 from single_kernel_mongo.utils.mongo_connection import NotReadyError
-from single_kernel_mongo.utils.mongodb_users import (
-    BackupUser,
-    MonitorUser,
-    OperatorUser,
-)
+from single_kernel_mongo.utils.mongodb_users import BackupUser, MonitorUser
 
 from charm import MongoDBK8sCharm
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -653,6 +653,7 @@ class TestCharm(unittest.TestCase):
         """NOTE: currently ops.testing seems to allow for non-leader to set secrets too!"""
         secret = self.harness.charm.operator.state.secrets.set("new-secret", "bla", scope)
         secret = self.harness.charm.model.get_secret(label=secret.label)
+        self.harness.set_leader(False)
 
         self.harness.charm.on.secret_changed.emit(label=secret.label, id=secret.id)
         connect_exporter.assert_called()
@@ -668,6 +669,7 @@ class TestCharm(unittest.TestCase):
         # "Hack": creating a secret outside of the normal MongodbOperatorCharm.set_secret workflow
         scope_obj = self.harness.charm.app if scope == Scope.APP else self.harness.charm.unit
         secret = scope_obj.add_secret({"key": "value"})
+        self.harness.set_leader(False)
 
         with self._caplog.at_level(logging.DEBUG):
             self.harness.charm.on.secret_changed.emit(label=secret.label, id=secret.id)
@@ -680,50 +682,29 @@ class TestCharm(unittest.TestCase):
         "single_kernel_mongo.managers.config.MongoDBExporterConfigManager.configure_and_restart"
     )
     def test_connect_to_mongo_exporter_on_set_password(
-        self, connect_exporter, mock_set_user_password
+        self,
+        connect_exporter,
+        mock_set_user_password,
     ):
         """Test _connect_mongodb_exporter is called when the password is set for 'monitor' user."""
         self.harness.set_leader(True)
-
-        self.harness.run_action("set-password", {"username": "monitor"})
+        system_users = {
+            "monitor": "abc",
+        }
+        secret_id = self.harness.add_model_secret("mongodb-k8s", system_users)
+        self.harness.update_config(
+            {
+                "system-users": f"{secret_id}",
+            }
+        )
         connect_exporter.assert_called()
-
-    @patch("single_kernel_mongo.utils.mongo_connection.MongoConnection.set_user_password")
-    @patch(
-        "single_kernel_mongo.managers.config.MongoDBExporterConfigManager.configure_and_restart"
-    )
-    def test_event_auto_reset_password_secrets_when_no_pw_value_shipped(
-        self, connect_exporter, set_user_password
-    ):
-        """Test _connect_mongodb_exporter is called when the password is set for 'montior' user.
-
-        Furthermore: in Juju 3.x we want to use secrets
-        """
-        self.harness.set_leader(True)
-
-        # Getting current password
-        params = {"username": "monitor"}
-        output = self.harness.run_action("set-password", params)
-        assert output.results["password"]
-        pw1 = output.results["password"]
-
-        connect_exporter.assert_called()
-
-        # New password was generated
-        params = {"username": "monitor"}
-        output = self.harness.run_action("set-password", params)
-        assert output.results["password"]
-        pw2 = output.results["password"]
-
-        # a new password was created
-        assert pw1 != pw2
 
     @patch("single_kernel_mongo.core.k8s_workload.KubernetesWorkload.exec")
     @patch("single_kernel_mongo.utils.mongo_connection.MongoConnection.set_user_password")
     @patch("single_kernel_mongo.managers.mongodb_operator.MongoDBOperator.handle_licenses")
     @patch("single_kernel_mongo.managers.mongodb_operator.MongoDBOperator.set_permissions")
     @patch("ops.framework.EventBase.defer")
-    def test__connect_mongodb_exporter_success(self, defer, *unused):
+    def test_connect_mongodb_exporter_success(self, defer, *unused):
         """Tests the _connect_mongodb_exporter method has been called."""
         # Get container
         container = self.harness.model.unit.get_container("mongod")
@@ -754,10 +735,16 @@ class TestCharm(unittest.TestCase):
         service = self.harness.model.unit.get_container("mongod").get_service("mongodb-exporter")
         assert service.is_running()
 
-        params = {"username": "monitor", "password": "mongo123"}
-        self.harness.run_action("set-password", params)
+        system_users = {"monitor": "mongo123"}
+        secret_id = self.harness.add_model_secret("mongodb-k8s", system_users)
+        self.harness.update_config(
+            {
+                "system-users": f"{secret_id}",
+            }
+        )
 
         password = self.harness.charm.operator.state.get_user_password(MonitorUser)
+        assert password == "mongo123"
 
         updated_plan = self.harness.get_container_pebble_plan("mongod").to_dict()
         new_uri = (
@@ -777,23 +764,37 @@ class TestCharm(unittest.TestCase):
         """Tests that a given password is set as the new mongodb password for backup user."""
         self.harness.set_leader(True)
         self.harness.charm.operator.state.db_initialised = True
-        params = {"password": "canonical123", "username": "backup"}
-        self.harness.run_action("set-password", params)
+        system_users = {"backup": "canonical123"}
+        secret_id = self.harness.add_model_secret("mongodb-k8s", system_users)
+        self.harness.update_config(
+            {
+                "system-users": f"{secret_id}",
+            }
+        )
+
         new_password = self.harness.charm.operator.state.get_user_password(BackupUser)
 
         # verify app data is updated and results are reported to user
         self.assertEqual("canonical123", new_password)
 
+    @patch("ops.framework.EventBase.defer")
     @patch("single_kernel_mongo.managers.backups.BackupManager.get_statuses")
-    def test_set_backup_password_pbm_busy(self, pbm_status):
+    def test_set_backup_password_pbm_busy(self, pbm_status, event_defer):
         """Tests changes to passwords fail when pbm is restoring/backing up."""
         self.harness.set_leader(True)
 
         pbm_status.return_value = [StatusObject(status="maintenance", message="pbm")]
 
-        for user in [BackupUser, MonitorUser, OperatorUser]:
-            original_password = self.harness.charm.operator.state.get_user_password(user)
-            with pytest.raises(ActionFailed):
-                self.harness.run_action("set-password", {"username": user.username})
-            current_password = self.harness.charm.operator.state.get_user_password(user)
-            self.assertEqual(current_password, original_password)
+        system_users = {
+            "operator": "123",
+            "monitor": "abc",
+            "logrotate": "something",
+            "backup": "123abc",
+        }
+        secret_id = self.harness.add_model_secret("mongodb-k8s", system_users)
+        self.harness.update_config(
+            {
+                "system-users": f"{secret_id}",
+            }
+        )
+        event_defer.assert_called()

--- a/tests/unit/test_mongodb_provider.py
+++ b/tests/unit/test_mongodb_provider.py
@@ -81,7 +81,7 @@ class TestMongoProvider(unittest.TestCase):
         statuses = self.harness.charm.operator.state.statuses.get(scope="unit", component="mongod")
         status = next(iter(statuses), None)
         assert as_status(status) == BlockedStatus(
-            "Sharding roles do not support database interface."
+            "The database relation cannot be used by sharding components (shards or config servers)."
         )
         oversee_users.assert_not_called()
 

--- a/tests/unit/test_upgrade.py
+++ b/tests/unit/test_upgrade.py
@@ -1,14 +1,13 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 import unittest
-from unittest.mock import Mock, PropertyMock, patch
+from unittest.mock import PropertyMock, patch
 
 import httpx
 import pytest
-from data_platform_helpers.advanced_statuses.models import StatusObject
 from lightkube import ApiError
 from ops.model import Relation
-from ops.testing import ActionFailed, Harness
+from ops.testing import Harness
 from parameterized import parameterized
 from single_kernel_mongo.config.literals import UnitState
 from single_kernel_mongo.core.kubernetes_upgrades import KubernetesUpgrade

--- a/tests/unit/test_upgrade.py
+++ b/tests/unit/test_upgrade.py
@@ -89,27 +89,6 @@ class TestUpgrades(unittest.TestCase):
         getattr(self.harness.charm.on[relation.name], handler).emit(relation)
         defer.assert_called()
 
-    @patch(
-        "single_kernel_mongo.state.charm_state.CharmState.upgrade_in_progress",
-        new_callable=PropertyMock,
-    )
-    def test_pass_pre_set_password_check_fails(self, mock_upgrade):
-        def mock_shard_role(role_name: str):
-            return role_name != "shard"
-
-        mock_pbm_status = Mock(return_value=[StatusObject(status="active", message="")])
-        self.harness.charm.is_role = mock_shard_role
-        mock_upgrade.return_value = True
-        self.harness.charm.operator.backup_manager.compute_statuses = mock_pbm_status
-
-        with self.assertRaises(ActionFailed) as action_failed:
-            self.harness.run_action("set-password")
-
-        assert (
-            action_failed.exception.message
-            == "Cannot set passwords while an upgrade is in progress"
-        )
-
     @parameterized.expand([[403, DeployedWithoutTrustError], [500, ApiError]])
     @patch("single_kernel_mongo.managers.k8s.K8sManager.get_partition")
     def test_lightkube_errors(self, status_code, expected_error, patch_get):


### PR DESCRIPTION
This PR propagate the changes in https://github.com/canonical/mongo-single-kernel-library/pull/83 to the mongodb-k8s-operator.

Now the internal user passwords will be managed with a config option (system-users) instead of using actions.