### PR TITLE
chore: update single-kernel to v1.8.16

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1629,14 +1629,14 @@ files = [
 
 [[package]]
 name = "mongo-charms-single-kernel"
-version = "1.8.15"
+version = "1.8.16"
 description = "Shared and reusable code for Mongo-related charms"
 optional = false
 python-versions = "<4.0,>=3.10"
 groups = ["main", "integration"]
 files = [
-    {file = "mongo_charms_single_kernel-1.8.15-py3-none-any.whl", hash = "sha256:15eb8389c79c215ef1229f8048508339810d6ab0d467675a2a9cbb47fb2ba3e7"},
-    {file = "mongo_charms_single_kernel-1.8.15.tar.gz", hash = "sha256:ad0be0ea257de0cc45ea07b1ea060430c3a810847d7272bff90f025794ad6b14"},
+    {file = "mongo_charms_single_kernel-1.8.16-py3-none-any.whl", hash = "sha256:38f9bee829e71481191cb5b92f0cc96fe0fa0ceb449b40ab2f04a4cd0bd31068"},
+    {file = "mongo_charms_single_kernel-1.8.16.tar.gz", hash = "sha256:01c1f3d4ba60588e56370416370b029b7208cb7965836af72a942a1e3cf03610"},
 ]
 
 [package.dependencies]
@@ -3293,4 +3293,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10.12"
-content-hash = "c3021b073e6d742efcd61413d5afe83c1061c9857315e58dc2a56da62c61755c"
+content-hash = "6917c83a08473e00d710383b9b90d6d840d6f4db46a319c20952b104572df6b1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires-poetry = ">=2.0.0"
 
 [tool.poetry.dependencies]
 python = "^3.10.12"
-mongo-charms-single-kernel = "1.8.15"
+mongo-charms-single-kernel = "1.8.16"
 ops = ">=2.21"
 pymongo = "^4.7.3"
 pyyaml = "^6.0.1"
@@ -62,7 +62,7 @@ isort = "^5.13.2"
 [tool.poetry.group.integration.dependencies]
 allure-pytest = "^2.13.5"
 ops = ">=2.21"
-mongo-charms-single-kernel = "1.8.15"
+mongo-charms-single-kernel = "1.8.16"
 pymongo = "^4.7.3"
 parameterized = "^0.9.0"
 lightkube = "^0.15.3"


### PR DESCRIPTION
## Issue
addresses https://github.com/canonical/mongodb-operator/issues/595

## Solution
update `mongo-charms-single-kernel` to v1.8.16