### PR TITLE
patch: Bump mongo-charms-single-kernel to v1.8.18

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1578,14 +1578,14 @@ files = [
 
 [[package]]
 name = "mongo-charms-single-kernel"
-version = "1.8.16"
+version = "1.8.18"
 description = "Shared and reusable code for Mongo-related charms"
 optional = false
 python-versions = "<4.0,>=3.10"
 groups = ["main", "integration"]
 files = [
-    {file = "mongo_charms_single_kernel-1.8.16-py3-none-any.whl", hash = "sha256:38f9bee829e71481191cb5b92f0cc96fe0fa0ceb449b40ab2f04a4cd0bd31068"},
-    {file = "mongo_charms_single_kernel-1.8.16.tar.gz", hash = "sha256:01c1f3d4ba60588e56370416370b029b7208cb7965836af72a942a1e3cf03610"},
+    {file = "mongo_charms_single_kernel-1.8.18-py3-none-any.whl", hash = "sha256:54187acd4fe2b2d9402a0f26fb89f7a0455396590285a2e7151fc79d43530c0e"},
+    {file = "mongo_charms_single_kernel-1.8.18.tar.gz", hash = "sha256:2ace3e23ce8bc559b10e5db11d7d60bba952ddc686221c2d89772384c5e6795a"},
 ]
 
 [package.dependencies]
@@ -3227,4 +3227,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10.12"
-content-hash = "6917c83a08473e00d710383b9b90d6d840d6f4db46a319c20952b104572df6b1"
+content-hash = "0c67a99641dfcbac3814d287c176a6832393175b2db9c0abe326a1b35bb5df28"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,6 @@ requires-poetry = ">=2.0.0"
 
 [tool.poetry.dependencies]
 python = "^3.10.12"
-mongo-charms-single-kernel = "1.8.16"
 ops = ">=2.21"
 pymongo = "^4.7.3"
 pyyaml = "^6.0.1"
@@ -20,6 +19,7 @@ lightkube = "^0.15.3"
 setuptools = "^72.0.0"
 rpds-py = "0.18.0"
 charm-refresh = "^3.1.0.3"
+mongo-charms-single-kernel = "v1.8.18"
 
 [tool.poetry.group.charm-libs.dependencies]
 ops = ">=2.21"
@@ -62,7 +62,6 @@ isort = "^5.13.2"
 [tool.poetry.group.integration.dependencies]
 allure-pytest = "^2.13.5"
 ops = ">=2.21"
-mongo-charms-single-kernel = "1.8.16"
 pymongo = "^4.7.3"
 parameterized = "^0.9.0"
 lightkube = "^0.15.3"
@@ -76,6 +75,7 @@ pytest-operator = "^0.36.0"
 pytest-operator-groups = {git = "https://github.com/canonical/data-platform-workflows", tag = "v35.0.4", subdirectory = "python/pytest_plugins/pytest_operator_groups"}
 pytest-github-secrets = {git = "https://github.com/canonical/data-platform-workflows", tag = "v35.0.4", subdirectory = "python/pytest_plugins/github_secrets"}
 allure-pytest-collection-report = {git = "https://github.com/canonical/data-platform-workflows", tag = "v35.0.4", subdirectory = "python/pytest_plugins/allure_pytest_collection_report"}
+mongo-charms-single-kernel = "v1.8.18"
 
 [build-system]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Automated bump of `mongo-charms-single-kernel` to version `v1.8.18` after PyPI release.