### PR TITLE
patch: Bump mongo-charms-single-kernel to version v1.8.19

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -77,7 +77,7 @@ parts:
       # rpds-py (Python package) >=0.19.0 requires rustc >=1.76, which is not available in the
       # Ubuntu 22.04 archive. Install rustc and cargo using rustup instead of the Ubuntu archive
       rustup set profile minimal
-      rustup default 1.83.0  # renovate: charmcraft-rust-latest
+      rustup default 1.92.0  # renovate: charmcraft-rust-latest
 
       craftctl default
       # Include requirements.txt in *.charm artifact for easier debugging

--- a/poetry.lock
+++ b/poetry.lock
@@ -1578,14 +1578,14 @@ files = [
 
 [[package]]
 name = "mongo-charms-single-kernel"
-version = "1.8.18"
+version = "1.8.19"
 description = "Shared and reusable code for Mongo-related charms"
 optional = false
 python-versions = "<4.0,>=3.10"
 groups = ["main", "integration"]
 files = [
-    {file = "mongo_charms_single_kernel-1.8.18-py3-none-any.whl", hash = "sha256:54187acd4fe2b2d9402a0f26fb89f7a0455396590285a2e7151fc79d43530c0e"},
-    {file = "mongo_charms_single_kernel-1.8.18.tar.gz", hash = "sha256:2ace3e23ce8bc559b10e5db11d7d60bba952ddc686221c2d89772384c5e6795a"},
+    {file = "mongo_charms_single_kernel-1.8.19-py3-none-any.whl", hash = "sha256:6930c0efc6032aef107f0c61031f2b5670e37f270187be54749af389cdf0553f"},
+    {file = "mongo_charms_single_kernel-1.8.19.tar.gz", hash = "sha256:ed67da0d7ebfb69c90a0d815ef08fd0f67b3d9a3a29a376e39ae115a0de2ad2e"},
 ]
 
 [package.dependencies]
@@ -3227,4 +3227,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10.12"
-content-hash = "0c67a99641dfcbac3814d287c176a6832393175b2db9c0abe326a1b35bb5df28"
+content-hash = "041df5942c68cbcee42a789ec2b7e120fd4b7e81d4232026cbeb2bc696277a69"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ lightkube = "^0.15.3"
 setuptools = "^72.0.0"
 rpds-py = "0.18.0"
 charm-refresh = "^3.1.0.3"
-mongo-charms-single-kernel = "v1.8.18"
+mongo-charms-single-kernel = "v1.8.19"
 
 [tool.poetry.group.charm-libs.dependencies]
 ops = ">=2.21"
@@ -75,7 +75,7 @@ pytest-operator = "^0.36.0"
 pytest-operator-groups = {git = "https://github.com/canonical/data-platform-workflows", tag = "v35.0.4", subdirectory = "python/pytest_plugins/pytest_operator_groups"}
 pytest-github-secrets = {git = "https://github.com/canonical/data-platform-workflows", tag = "v35.0.4", subdirectory = "python/pytest_plugins/github_secrets"}
 allure-pytest-collection-report = {git = "https://github.com/canonical/data-platform-workflows", tag = "v35.0.4", subdirectory = "python/pytest_plugins/allure_pytest_collection_report"}
-mongo-charms-single-kernel = "v1.8.18"
+mongo-charms-single-kernel = "v1.8.19"
 
 [build-system]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Includes:
- patch: fix permissions in tmp storage https://github.com/canonical/mongo-single-kernel-library/pull/157