### PR TITLE
fix: missing perms

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,6 +21,7 @@ jobs:
     needs: tag
     uses: ./.github/workflows/ci.yaml
     permissions:
+      actions: read
       contents: write
 
   release:


### PR DESCRIPTION
Missing `actions: read` on tag workflow