### PR TITLE
patch: fix release workflow and lint check

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,6 +20,7 @@ jobs:
     with:
       track: 6
       artifact-prefix: ${{ needs.ci-tests.outputs.artifact-prefix }}
+      charmcraft-snap-revision: "8022"
     secrets:
       charmhub-token: ${{ secrets.CHARMHUB_TOKEN }}
     permissions:

--- a/.github/zizmor.yaml
+++ b/.github/zizmor.yaml
@@ -14,6 +14,13 @@ rules:
         - actions/*
         - docker/login-action
         - tiobe/tics-github-action
+        - astral-sh/ruff-pre-commit
+        - codespell-project/codespell
+        - python-poetry/poetry
+        - pre-commit/pre-commit-hooks
+        - pre-commit/mirrors-mypy
+        - rhysd/actionlint
+        - zizmorcore/zizmor-pre-commit
   # Pinning actions to a commit SHA has a security tradeoff—pinned actions cannot be later
   # compromised, but they also cannot be security patched.
   # Above (in `forbidden-uses`), we restrict actions usage to organizations that we trust to have

--- a/.github/zizmor.yaml
+++ b/.github/zizmor.yaml
@@ -36,3 +36,6 @@ rules:
         actions/*: ref-pin
         docker/login-action: ref-pin
         tiobe/tics-github-action: ref-pin
+  self-repository:
+    # TODO: Re enable this when actionlint is fixed
+    disable: true


### PR DESCRIPTION
### Description

The lint job is failing:

https://github.com/canonical/mongodb-k8s-operator/actions/runs/33483563728/job/99799600636?pr=592

So this PR is fix for that

It also backports
https://github.com/canonical/mongodb-k8s-operator/pull/589