### PR TITLE
patch: move to canonical k8s

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -32,8 +32,8 @@ Juju agent:
 <!-- App revision from `juju status` or (advanced) commit hash -->
 Charm revision: 
 
-<!-- Run `microk8s version` -->
-microk8s: 
+<!-- K8s distribution and version -->
+k8s:
 
 ## Log output
 <!-- Please enable debug logging by running `juju model-config logging-config="<root>=INFO;unit=DEBUG"` (if possible) -->

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,7 +30,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
       - name: Install tox & poetry
@@ -80,7 +80,7 @@ jobs:
     permissions: {}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -97,28 +97,66 @@ jobs:
       - name: (self hosted) Disk usage
         run: df --human-readable
 
+      - name: Purge Docker
+        # GitHub-hosted Azure runners ship Docker pre-installed and active.
+        # Canonical K8s requires "A system with no previous installations
+        # of containerd/docker as this may cause conflicts"
+        # (see https://documentation.ubuntu.com/canonical-kubernetes
+        # /release-1.32/snap/tutorial/getting-started/).
+        # Completely purging Docker requires also
+        # deleting the Docker-specific `iptables-nft` rulesets
+        # created on installation.
+        timeout-minutes: 5
+        run: |
+          sudo apt-get remove --purge -y docker-ce docker-ce-cli containerd.io docker.io containerd 2>/dev/null || true
+          sudo nft flush ruleset
+          sudo ip link delete docker0 2>/dev/null || true
+
+      - name: Remove podman CNI bridge config
+        # Ubuntu 24.04 runners ship podman with a CNI bridge config
+        # (/etc/cni/net.d/87-podman-bridge.conflist) that sorts
+        # lexicographically before Cilium's config (05-cilium.conflist).
+        # When that file is present, containerd picks the podman bridge
+        # as the active CNI before Cilium is ready, bypassing the
+        # node.kubernetes.io/network-unavailable taint and scheduling
+        # pods onto the 10.88.0.0/16 bridge instead of the Cilium pod
+        # CIDR. Removing the file ensures Cilium is the only CNI plugin
+        # from the start.
+        timeout-minutes: 1
+        run: |
+          sudo rm -f /etc/cni/net.d/87-podman-bridge.conflist
+
       - name: Install terraform snap
         run: |
           sudo snap install terraform --channel=latest/stable --classic
 
-      - name: Install Juju
-        run: |
-          sudo snap install juju --channel=3.6
+      - name: Install concierge
+        run: sudo snap install --classic concierge
 
-      - name: microk8s setup
-        run: |
-          sudo snap install microk8s --channel=1.35-strict/stable
-          sudo usermod -a -G snap_microk8s "$(whoami)"
-          mkdir -p ~/.kube
-          sudo chown -R "$(whoami)" ~/.kube
-          newgrp snap_microk8s
-          sudo microk8s enable dns storage ingress
+      - name: K8s + Juju setup
+        # Uses the `k8s` provider defined in ./concierge.yaml to install
+        # Canonical K8s, bootstrap it, and bootstrap a Juju controller on it
+        # (replaces the previous manual microk8s + juju bootstrap steps).
+        env:
+          CONCIERGE_JUJU_CHANNEL: 3.6/stable
+        run: sudo concierge prepare --trace
 
-      - name: Juju setup
+      - name: Wait for K8s workloads
+        # `k8s status --wait-ready` returns as soon as 1 node is ready
+        # (see https://github.com/canonical/k8s-snap/issues/1789)
+        # but Cilium, CoreDNS, and storage may still be initialising
         run: |
-          mkdir -p ~/.local/share/juju
-          sudo --user "$USER" juju bootstrap 'microk8s' --config model-logs-size=10G
-          juju model-defaults logging-config='<root>=INFO; unit=DEBUG'
+          for res in deployment/cilium-operator deployment/coredns deployment/metrics-server daemonset/cilium daemonset/ck-storage-rawfile-csi-node statefulset/ck-storage-rawfile-csi-controller; do
+              if sudo k8s kubectl -n kube-system get "$res" >/dev/null 2>&1; then
+                  sudo k8s kubectl -n kube-system rollout status "$res" --timeout=5m
+              else
+                  echo "Skipping rollout status for missing $res"
+              fi
+          done
+
+      - name: Juju model setup
+        run: |
+          juju controller-config model-logs-size=10G
           juju add-model "test-${{ matrix.product_module }}"
 
       - name: Terraform deploy - ${{ matrix.product_module }} product module

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -136,7 +136,6 @@ jobs:
       - name: K8s + Juju setup
         # Uses the `k8s` provider defined in ./concierge.yaml to install
         # Canonical K8s, bootstrap it, and bootstrap a Juju controller on it
-        # (replaces the previous manual microk8s + juju bootstrap steps).
         env:
           CONCIERGE_JUJU_CHANNEL: 3.6/stable
         run: sudo concierge prepare --trace

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -17,7 +17,7 @@ jobs:
     permissions: {}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
       - name: Set up environment
@@ -89,9 +89,36 @@ jobs:
       - name: Disk usage
         timeout-minutes: 1
         run: df --human-readable
+      - name: Purge Docker
+        # GitHub-hosted Azure runners ship Docker pre-installed and active.
+        # Canonical K8s requires "A system with no previous installations
+        # of containerd/docker as this may cause conflicts"
+        # (see https://documentation.ubuntu.com/canonical-kubernetes
+        # /release-1.32/snap/tutorial/getting-started/).
+        # Completely purging Docker requires also
+        # deleting the Docker-specific `iptables-nft` rulesets
+        # created on installation.
+        timeout-minutes: 5
+        run: |
+          sudo apt-get remove --purge -y docker-ce docker-ce-cli containerd.io docker.io containerd 2>/dev/null || true
+          sudo nft flush ruleset
+          sudo ip link delete docker0 2>/dev/null || true
+      - name: Remove podman CNI bridge config
+        # Ubuntu 24.04 runners ship podman with a CNI bridge config
+        # (/etc/cni/net.d/87-podman-bridge.conflist) that sorts
+        # lexicographically before Cilium's config (05-cilium.conflist).
+        # When that file is present, containerd picks the podman bridge
+        # as the active CNI before Cilium is ready, bypassing the
+        # node.kubernetes.io/network-unavailable taint and scheduling
+        # pods onto the 10.88.0.0/16 bridge instead of the Cilium pod
+        # CIDR. Removing the file ensures Cilium is the only CNI plugin
+        # from the start.
+        timeout-minutes: 1
+        run: |
+          sudo rm -f /etc/cni/net.d/87-podman-bridge.conflist
       - name: Checkout
         timeout-minutes: 3
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
       - name: Setup python 3.12
@@ -108,7 +135,7 @@ jobs:
           go install github.com/canonical/spread/cmd/spread@latest
       - name: Download packed charm(s)
         timeout-minutes: 5
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           pattern: ${{ inputs.artifact-prefix }}-*
           merge-multiple: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -55,7 +55,7 @@ jobs:
       RELEASES_BRANCH: releases
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 
@@ -74,7 +74,7 @@ jobs:
           echo "pip-version=${VERSION}" >> "${GITHUB_OUTPUT}"
 
       - name: Checkout releases
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           persist-credentials: true
           ref: ${{ env.RELEASES_BRANCH }}
@@ -129,7 +129,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
       - name: Get charm name

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ clean:
 
 pod-logs:
 # workload container logs
-	microk8s.kubectl logs pod/$(app)-$(unit) --namespace=$(model) --container $(workload) -f
+	sudo k8s kubectl logs pod/$(app)-$(unit) --namespace=$(model) --container $(workload) -f
 
 debug-hook:
 # debug hook for given unit
@@ -55,15 +55,15 @@ debug-hook:
 
 ssh-workload-container:
 # ssh into workload container for given unit (default=0)
-	microk8s.kubectl exec -n $(model) -it $(app)-$(unit) --container $(workload)  -- /bin/bash
+	sudo k8s kubectl exec -n $(model) -it $(app)-$(unit) --container $(workload)  -- /bin/bash
 
 ssh-charm-container:
 # ssh into charm container for given unit (default=0)
-	microk8s.kubectl exec -n $(model) -it $(app)-$(unit) -- /bin/bash
+	sudo k8s kubectl exec -n $(model) -it $(app)-$(unit) -- /bin/bash
 
 prune-pvcs:
 # remove dangling pvcs
-	for i in $$(microk8s.kubectl get pvc -n $(model)|grep database| awk "{ print $$1 }"); do microk8s.kubectl delete pvc/$${i} -n $(model); done
+	for i in $$(sudo k8s kubectl get pvc -n $(model)|grep database| awk "{ print $$1 }"); do sudo k8s kubectl delete pvc/$${i} -n $(model); done
 
 get-credentials:
 # run mysql specific action on leader 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Charmed MongoDB on Kubernetes
 [![CharmHub Badge](https://charmhub.io/mongodb-k8s/badge.svg)](https://charmhub.io/mongodb-k8s)
-[![Release to 6/edge](https://github.com/canonical/mongodb-k8s-operator/actions/workflows/release.yaml/badge.svg)](https://github.com/canonical/mongodb-k8s-operator/actions/workflows/release.yaml)
+[![Release to 8/edge](https://github.com/canonical/mongodb-k8s-operator/actions/workflows/release.yaml/badge.svg)](https://github.com/canonical/mongodb-k8s-operator/actions/workflows/release.yaml)
 [![Tests](https://github.com/canonical/mongodb-k8s-operator/actions/workflows/ci.yaml/badge.svg)](https://github.com/canonical/mongodb-k8s-operator/actions/workflows/ci.yaml)
 ## Overview
 

--- a/concierge.yaml
+++ b/concierge.yaml
@@ -2,13 +2,12 @@ juju:
   model-defaults:
     logging-config: <root>=INFO; unit=DEBUG
 providers:
-  microk8s:
+  k8s:
     enable: true
     bootstrap: true
-    addons:
-      - dns
-      - hostpath-storage
-      - metallb:10.64.140.43-10.64.140.49
+    channel: 1.35-classic/stable
+    bootstrap-constraints:
+      root-disk: 5G
 host:
   snaps:
     jhack:

--- a/spread.yaml
+++ b/spread.yaml
@@ -96,7 +96,6 @@ backends:
       # To install pipx on self-hosted runners
       CONCIERGE_EXTRA_DEBS: pipx,build-essential,python3-dev,libldap-dev,libsasl2-dev
       DOCKERHUB_MIRROR: "$(HOST: echo $DOCKERHUB_MIRROR)"
-      CONCIERGE_MICROK8S_CHANNEL: 1.35-strict/stable
       # Python 3.12
       LD_LIBRARY_PATH: "$(HOST: echo $LD_LIBRARY_PATH)"
       PKG_CONFIG_PATH: "$(HOST: echo $PKG_CONFIG_PATH)"
@@ -124,30 +123,6 @@ prepare: |
   cd "$SPREAD_PATH"
   snap install --classic concierge
 
-  if [[ -n "$DOCKERHUB_MIRROR" ]]
-  then
-    # Running on IS-hosted runner; configure microk8s to use Docker Hub mirror
-    # Run before concierge prepare because of https://github.com/canonical/concierge/issues/75
-
-    snap install microk8s --channel "$CONCIERGE_MICROK8S_CHANNEL" --classic
-
-    # Wait for microk8s to populate iptables
-    # https://chat.canonical.com/canonical/pl/jo5cg6wqjjrudqd5ybj6hhttee
-    until [[ -n $(iptables --list | grep -i "microk8s") ]]
-    do
-      echo "MicroK8s has not yet configured iptables."
-      sleep 10
-    done
-
-    tee /var/snap/microk8s/current/args/certs.d/docker.io/hosts.toml << EOF
-    server = "$DOCKERHUB_MIRROR"
-    [host."${DOCKERHUB_MIRROR#'https://'}"]
-    capabilities = ["pull", "resolve"]
-  EOF
-    microk8s stop
-    microk8s start
-  fi
-
   # Install pipx (on lxd-vm backend)
   pipx install tox poetry
   pipx ensurepath
@@ -157,6 +132,17 @@ prepare-each: |
   cd "$SPREAD_PATH"
   # `concierge prepare` needs to be run for each spread job in case Juju version changed
   concierge prepare --trace
+
+  # k8s status --wait-ready returns as soon as 1 node is ready
+  # (see https://github.com/canonical/k8s-snap/issues/1789)
+  # but Cilium, CoreDNS, and storage may still be initialising
+  for res in deployment/cilium-operator deployment/coredns deployment/metrics-server daemonset/cilium daemonset/ck-storage-rawfile-csi-node statefulset/ck-storage-rawfile-csi-controller; do
+      if k8s kubectl -n kube-system get "$res" >/dev/null 2>&1; then
+          k8s kubectl -n kube-system rollout status "$res" --timeout=5m
+      else
+          echo "Skipping rollout status for missing $res"
+      fi
+  done
 
   # Unable to set constraint on all models because of Juju bug:
   # https://bugs.launchpad.net/juju/+bug/2065050

--- a/spread.yaml
+++ b/spread.yaml
@@ -100,9 +100,9 @@ backends:
       LD_LIBRARY_PATH: "$(HOST: echo $LD_LIBRARY_PATH)"
       PKG_CONFIG_PATH: "$(HOST: echo $PKG_CONFIG_PATH)"
     systems:
-      - ubuntu-22.04:
+      - ubuntu-24.04:
           username: runner
-      - ubuntu-22.04-arm:
+      - ubuntu-24.04-arm:
           username: runner
 
 suites:

--- a/tests/spread/test_charm.py/task.yaml
+++ b/tests/spread/test_charm.py/task.yaml
@@ -2,7 +2,7 @@ summary: test_charm.py
 environment:
   TEST_MODULE: test_charm.py
 systems:
-  - ubuntu-22.04
-  - ubuntu-22.04-arm
+  - ubuntu-24.04
+  - ubuntu-24.04-arm
 execute: |
   tox run -e integration -- "tests/integration/$TEST_MODULE" --model testing

--- a/tests/spread/test_sharding.py/task.yaml
+++ b/tests/spread/test_sharding.py/task.yaml
@@ -2,7 +2,7 @@ summary: test_sharding.py
 environment:
   TEST_MODULE: test_sharding.py
 systems:
-  - ubuntu-22.04
-  - ubuntu-22.04-arm
+  - ubuntu-24.04
+  - ubuntu-24.04-arm
 execute: |
   tox run -e integration -- "tests/integration/$TEST_MODULE" --model testing


### PR DESCRIPTION
## Description

This PR moves the CI ands tests to use canonical k8s
It is based on https://github.com/canonical/valkey-operator/pull/85 and https://github.com/canonical/opensearch-single-kernel-library/pull/93

I have a local deployment of a sharded cluster working on canonical k8s

<img width="922" height="964" alt="image" src="https://github.com/user-attachments/assets/7c36be9c-e0a5-42ad-a423-792f5ad4cd44" />